### PR TITLE
[Feature] HY2Switch 공통 컴포넌트를 구현합니다.

### DIFF
--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Switch.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Switch.kt
@@ -37,35 +37,37 @@ fun HY2Switch(
 ) {
     val background: Color by animateColorAsState(
         targetValue = if (isChecked) checkedBackgroundColor else unCheckedBackgroundColor,
-        label = "backgroundColorAnimation"
+        label = "backgroundColorAnimation",
     )
     val offset: Dp by animateDpAsState(
         targetValue = if (isChecked) 23.dp else 3.dp,
-        label = "offsetAnimation"
+        label = "offsetAnimation",
     )
 
     val interactionSource = remember { MutableInteractionSource() }
 
     Box(
-        modifier = Modifier
-            .size(width = 50.dp, height = 50.dp)
-            .padding(vertical = 10.dp)
-            .clip(RoundedCornerShape(100.dp))
-            .background(background)
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null
-            ) {
-                onCheckedChanged(isChecked.not())
-            },
-        contentAlignment = Alignment.CenterStart
+        modifier =
+            Modifier
+                .size(width = 50.dp, height = 50.dp)
+                .padding(vertical = 10.dp)
+                .clip(RoundedCornerShape(100.dp))
+                .background(background)
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                ) {
+                    onCheckedChanged(isChecked.not())
+                },
+        contentAlignment = Alignment.CenterStart,
     ) {
         Box(
-            modifier = Modifier
-                .offset(x = offset)
-                .size(24.dp)
-                .clip(CircleShape)
-                .background(White)
+            modifier =
+                Modifier
+                    .offset(x = offset)
+                    .size(24.dp)
+                    .clip(CircleShape)
+                    .background(White),
         )
     }
 }

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Switch.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Switch.kt
@@ -1,0 +1,81 @@
+package com.teamhy2.designsystem.common
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.teamhy2.designsystem.ui.theme.Blue100
+import com.teamhy2.designsystem.ui.theme.Gray200
+import com.teamhy2.designsystem.ui.theme.HY2Theme
+import com.teamhy2.designsystem.ui.theme.White
+
+@Composable
+fun HY2Switch(
+    isChecked: Boolean,
+    onCheckedChanged: (Boolean) -> Unit,
+    checkedBackgroundColor: Color = Blue100,
+    unCheckedBackgroundColor: Color = Gray200,
+) {
+    val background: Color by animateColorAsState(
+        targetValue = if (isChecked) checkedBackgroundColor else unCheckedBackgroundColor,
+        label = "backgroundColorAnimation"
+    )
+    val offset: Dp by animateDpAsState(
+        targetValue = if (isChecked) 23.dp else 3.dp,
+        label = "offsetAnimation"
+    )
+
+    val interactionSource = remember { MutableInteractionSource() }
+
+    Box(
+        modifier = Modifier
+            .size(width = 50.dp, height = 50.dp)
+            .padding(vertical = 10.dp)
+            .clip(RoundedCornerShape(100.dp))
+            .background(background)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null
+            ) {
+                onCheckedChanged(isChecked.not())
+            },
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Box(
+            modifier = Modifier
+                .offset(x = offset)
+                .size(24.dp)
+                .clip(CircleShape)
+                .background(White)
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun HY2SwitchPreview() {
+    var isChecked by remember { mutableStateOf(false) }
+
+    HY2Theme {
+        HY2Switch(isChecked, onCheckedChanged = { isChecked = it })
+    }
+}

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Switch.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Switch.kt
@@ -32,6 +32,7 @@ import com.teamhy2.designsystem.ui.theme.White
 fun HY2Switch(
     isChecked: Boolean,
     onCheckedChanged: (Boolean) -> Unit,
+    thumbColor: Color = White,
     checkedBackgroundColor: Color = Blue100,
     unCheckedBackgroundColor: Color = Gray200,
 ) {
@@ -67,7 +68,7 @@ fun HY2Switch(
                     .offset(x = offset)
                     .size(24.dp)
                     .clip(CircleShape)
-                    .background(White),
+                    .background(thumbColor),
         )
     }
 }


### PR DESCRIPTION
resolved #11 

## AS-IS
공통적으로 사용될 컴포넌트인 스위치를

## TO-BE
디자인 시스템에 구현합니다.

## KEY-POINT
- 디자인적 통일성과 offset 관련 문제로 컴포넌트는 `Modifier`를 받지 않습니다.
- animation label의 경우 android studio에서 애니메이션을 확인할 때 다른 애니메이션들과 식별하기 위해서 사용하는 것이기에 굳이 상수화 하지 않았습니다.
- 크기 관련 dp 들도 상수화 하지 않았습니다.
    - 디자인 상으론 스위치 컴포넌트의 높이가 `30dp`로 최소 터치 영역 크기를 위반하기에 패딩으로 터치영역을 넓히게끔 하였습니다.
    - 만약 디자인이 바뀌어 최소 터치 영역을 만족하는 높이가 된다면 패딩을 주지 않아도 되어 dp 수치 뿐만 아니라 코드 자체에도 변경사항이 생기기 때문에 상수화로는 변화에 대응할 수 없다 판단하여 과감하게 상수화하지 않았습니다.
- 스위치 Thumb가 움직이는 것에 대한 애니메이션, 백그라운드 색상이 변경되는 것에 애니메이션을 두어 좀 더 부드러운 사용자 경험을 받을 수 있게 해보았습니다.
    - 임의로 일단 한거라 추후 디자이너분에게 컨펌 다시 받아도 좋을듯 합니다.



## SCREENSHOT (Optional)
![hy2switch_test](https://github.com/user-attachments/assets/0c15bca1-d8ae-4922-8dac-ec2922a14034)
