### PR TITLE
[Feature] HY2Button 공통 컴포넌트를 구현합니다.

### DIFF
--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
@@ -2,7 +2,7 @@ package com.teamhy2.designsystem.common
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -13,8 +13,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.teamhy2.designsystem.ui.theme.Blue100
-import com.teamhy2.designsystem.ui.theme.Gray100
-import com.teamhy2.designsystem.ui.theme.Gray600
 import com.teamhy2.designsystem.ui.theme.HY2Theme
 import com.teamhy2.designsystem.ui.theme.White
 
@@ -38,7 +36,7 @@ fun HY2Button(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(8.dp),
+                .height(44.dp),
     ) {
         Text(
             text = text,
@@ -55,12 +53,6 @@ private fun HY2ButtonPreview() {
         Column {
             HY2Button(
                 text = "열람실 이용 연장",
-                onClick = { /* TODO */ },
-            )
-            HY2Button(
-                text = "커스텀 배경색 버튼",
-                backgroundColor = Gray600,
-                textColor = Gray100,
                 onClick = { /* TODO */ },
             )
         }

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
@@ -1,0 +1,72 @@
+package com.teamhy2.designsystem.common
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.teamhy2.designsystem.ui.theme.Blue100
+import com.teamhy2.designsystem.ui.theme.Gray100
+import com.teamhy2.designsystem.ui.theme.Gray600
+import com.teamhy2.designsystem.ui.theme.HY2Theme
+import com.teamhy2.designsystem.ui.theme.White
+
+private const val ROUNDED_CORNER_SIZE = 4
+private const val PADDING_SIZE = 8
+
+@Composable
+fun HY2Button(
+    text: String,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = Blue100,
+    textColor: Color = White,
+    onClick: () -> Unit,
+) {
+    Button(
+        onClick = onClick,
+        colors =
+            ButtonDefaults.buttonColors(
+                containerColor = backgroundColor,
+                contentColor = textColor,
+            ),
+        shape = RoundedCornerShape(ROUNDED_CORNER_SIZE.dp),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(PADDING_SIZE.dp)
+                .clip(RoundedCornerShape(ROUNDED_CORNER_SIZE.dp)),
+    ) {
+        Text(
+            text = text,
+            color = textColor,
+            style = HY2Theme.typography.body02,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun HY2ButtonPreview() {
+    HY2Theme {
+        Column {
+            HY2Button(
+                text = "열람실 이용 연장",
+                onClick = { /* TODO */ },
+            )
+            HY2Button(
+                text = "커스텀 배경색 버튼",
+                backgroundColor = Gray600,
+                textColor = Gray100,
+                onClick = { /* TODO */ },
+            )
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
@@ -9,7 +9,6 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -39,8 +38,7 @@ fun HY2Button(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(8.dp)
-                .clip(RoundedCornerShape(ROUNDED_CORNER_SIZE.dp)),
+                .padding(8.dp),
     ) {
         Text(
             text = text,

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
@@ -1,6 +1,5 @@
 package com.teamhy2.designsystem.common
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -13,6 +12,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.teamhy2.designsystem.ui.theme.Blue100
+import com.teamhy2.designsystem.ui.theme.Gray100
+import com.teamhy2.designsystem.ui.theme.Gray600
 import com.teamhy2.designsystem.ui.theme.HY2Theme
 import com.teamhy2.designsystem.ui.theme.White
 
@@ -50,11 +51,22 @@ fun HY2Button(
 @Composable
 private fun HY2ButtonPreview() {
     HY2Theme {
-        Column {
-            HY2Button(
-                text = "열람실 이용 연장",
-                onClick = { /* TODO */ },
-            )
-        }
+        HY2Button(
+            text = "열람실 이용 연장",
+            onClick = { /* TODO */ },
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HY2ButtonDifferentColorPreview() {
+    HY2Theme {
+        HY2Button(
+            text = "커스텀 배경색 버튼",
+            backgroundColor = Gray600,
+            textColor = Gray100,
+            onClick = { /* TODO */ },
+        )
     }
 }

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
@@ -20,12 +20,10 @@ import com.teamhy2.designsystem.ui.theme.HY2Theme
 import com.teamhy2.designsystem.ui.theme.White
 
 private const val ROUNDED_CORNER_SIZE = 4
-private const val PADDING_SIZE = 8
 
 @Composable
 fun HY2Button(
     text: String,
-    modifier: Modifier = Modifier,
     backgroundColor: Color = Blue100,
     textColor: Color = White,
     onClick: () -> Unit,
@@ -39,9 +37,9 @@ fun HY2Button(
             ),
         shape = RoundedCornerShape(ROUNDED_CORNER_SIZE.dp),
         modifier =
-            modifier
+            Modifier
                 .fillMaxWidth()
-                .padding(PADDING_SIZE.dp)
+                .padding(8.dp)
                 .clip(RoundedCornerShape(ROUNDED_CORNER_SIZE.dp)),
     ) {
         Text(

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
@@ -25,6 +25,7 @@ fun HY2Button(
     backgroundColor: Color = Blue100,
     textColor: Color = White,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Button(
         onClick = onClick,
@@ -35,7 +36,7 @@ fun HY2Button(
             ),
         shape = RoundedCornerShape(ROUNDED_CORNER_SIZE.dp),
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
                 .height(44.dp),
     ) {

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
@@ -17,7 +17,8 @@ import com.teamhy2.designsystem.ui.theme.Gray600
 import com.teamhy2.designsystem.ui.theme.HY2Theme
 import com.teamhy2.designsystem.ui.theme.White
 
-private const val ROUNDED_CORNER_SIZE = 4
+private const val BUTTON_ROUNDED_CORNER_SIZE = 4
+private const val BUTTON_HEIGHT = 44
 
 @Composable
 fun HY2Button(
@@ -34,11 +35,11 @@ fun HY2Button(
                 containerColor = backgroundColor,
                 contentColor = textColor,
             ),
-        shape = RoundedCornerShape(ROUNDED_CORNER_SIZE.dp),
+        shape = RoundedCornerShape(BUTTON_ROUNDED_CORNER_SIZE),
         modifier =
             modifier
                 .fillMaxWidth()
-                .height(44.dp),
+                .height(BUTTON_HEIGHT.dp),
     ) {
         Text(
             text = text,

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
@@ -50,7 +50,7 @@ fun HY2Button(
 
 @Preview(showBackground = true)
 @Composable
-fun HY2ButtonPreview() {
+private fun HY2ButtonPreview() {
     HY2Theme {
         Column {
             HY2Button(


### PR DESCRIPTION
resolved #10 

## AS-IS
재사용 가능성이 높아보이는 텍스트가 포함된 버튼을

## TO-BE
디자인 시스템에 구현합니다.

## KEY-POINT
- 디자인적 통일성을 위해 `Modifer`를 받지 않았는데 가로길이나 높이를 다르게 하는 확장성을 위해 받아야할지 고민입니다.
- switch PR에서 언급하셨던 것과 같은 이유로 크기관련 dp는 상수화하지 않았습니다.
- `ROUNDED_CORNER_SIZE`는 clip에서도 사용하고 디자인이 바뀌어도 크게 변경되지 않을 것 같아 상수화하였습니다.
- 버튼 눌림 효과는 기본 컴포넌트 그대로 사용하였습니다.

## SCREENSHOT (Optional)

https://github.com/user-attachments/assets/7abcb9f4-015d-44da-b0b4-0b8082f101b5

