### PR TITLE
[Feature] HY2Dialog 공통 컴포넌트를 구현합니다.

### DIFF
--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
@@ -32,8 +32,8 @@ import com.teamhy2.designsystem.ui.theme.Gray800
 import com.teamhy2.designsystem.ui.theme.HY2Theme
 import com.teamhy2.designsystem.ui.theme.White
 
-private val DIALOG_MARGIN = 30.dp
-private val DIALOG_CORNER_RADIUS = RoundedCornerShape(8.dp)
+private const val DIALOG_MARGIN = 30
+private const val DIALOG_CORNER_RADIUS = 8
 
 @Composable
 fun HY2Dialog(
@@ -60,9 +60,9 @@ fun HY2Dialog(
         Surface(
             modifier =
                 modifier
-                    .width(screenWidth - DIALOG_MARGIN * 2)
+                    .width(screenWidth - DIALOG_MARGIN.dp * 2)
                     .wrapContentHeight(),
-            shape = DIALOG_CORNER_RADIUS,
+            shape = RoundedCornerShape(DIALOG_CORNER_RADIUS.dp),
             color = backgroundColor,
         ) {
             Column(
@@ -105,8 +105,8 @@ fun HY2Dialog(
     }
 }
 
-private val BUTTON_CORNER_RADIUS = 8.dp
-private val BUTTON_HEIGHT = 46.dp
+private const val BUTTON_CORNER_RADIUS = 8
+private const val BUTTON_HEIGHT = 46
 
 @Composable
 private fun HY2DialogButton(
@@ -119,11 +119,11 @@ private fun HY2DialogButton(
     Button(
         onClick = onClick,
         colors = ButtonDefaults.buttonColors(containerColor = buttonColor),
-        shape = RoundedCornerShape(BUTTON_CORNER_RADIUS),
+        shape = RoundedCornerShape(BUTTON_CORNER_RADIUS.dp),
         contentPadding = PaddingValues(horizontal = 20.dp),
         modifier =
             modifier
-                .height(BUTTON_HEIGHT),
+                .height(BUTTON_HEIGHT.dp),
     ) {
         Text(
             text = text,

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
@@ -20,10 +20,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.DialogWindowProvider
 import com.teamhy2.designsystem.ui.theme.Blue100
 import com.teamhy2.designsystem.ui.theme.Gray100
 import com.teamhy2.designsystem.ui.theme.Gray200
@@ -57,6 +59,7 @@ fun HY2Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(dismissOnBackPress = true, dismissOnClickOutside = false),
     ) {
+        (LocalView.current.parent as DialogWindowProvider).window.setDimAmount(0.75f)
         Surface(
             modifier =
                 modifier

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
@@ -1,0 +1,149 @@
+package com.teamhy2.designsystem.common
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.teamhy2.designsystem.ui.theme.Blue100
+import com.teamhy2.designsystem.ui.theme.Gray100
+import com.teamhy2.designsystem.ui.theme.Gray200
+import com.teamhy2.designsystem.ui.theme.Gray600
+import com.teamhy2.designsystem.ui.theme.Gray800
+import com.teamhy2.designsystem.ui.theme.HY2Theme
+import com.teamhy2.designsystem.ui.theme.White
+
+private val DIALOG_MARGIN = 30.dp
+private val DIALOG_CORNER_RADIUS = RoundedCornerShape(8.dp)
+
+@Composable
+fun HY2Dialog(
+    description: String,
+    leftButtonText: String,
+    rightButtonText: String,
+    onLeftButtonClick: () -> Unit,
+    onRightButtonClick: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = Gray800,
+    leftButtonColor: Color = Blue100,
+    rightButtonColor: Color = Gray600,
+    leftButtonTextColor: Color = White,
+    rightButtonTextColor: Color = Gray200,
+) {
+    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(dismissOnBackPress = true, dismissOnClickOutside = false),
+    ) {
+        Surface(
+            modifier =
+                modifier
+                    .width(screenWidth - DIALOG_MARGIN * 2)
+                    .wrapContentHeight(),
+            shape = DIALOG_CORNER_RADIUS,
+            color = backgroundColor,
+        ) {
+            Column(
+                modifier =
+                    Modifier
+                        .padding(start = 24.dp, top = 40.dp, end = 24.dp, bottom = 24.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = description,
+                    color = Gray100,
+                    style = HY2Theme.typography.title02,
+                    modifier = Modifier.padding(bottom = 16.dp),
+                )
+                Spacer(modifier = Modifier.height(32.dp))
+                Row(
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    HY2DialogButton(
+                        text = rightButtonText,
+                        onClick = onRightButtonClick,
+                        buttonColor = rightButtonColor,
+                        textColor = rightButtonTextColor,
+                        modifier = modifier.weight(1f),
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    HY2DialogButton(
+                        text = leftButtonText,
+                        onClick = onLeftButtonClick,
+                        buttonColor = leftButtonColor,
+                        textColor = leftButtonTextColor,
+                        modifier = modifier.weight(1f),
+                    )
+                }
+            }
+        }
+    }
+}
+
+private val BUTTON_CORNER_RADIUS = 8.dp
+private val BUTTON_HEIGHT = 46.dp
+private val BUTTON_PADDING = PaddingValues(horizontal = 20.dp)
+
+@Composable
+private fun HY2DialogButton(
+    text: String,
+    onClick: () -> Unit,
+    buttonColor: Color,
+    textColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        colors = ButtonDefaults.buttonColors(containerColor = buttonColor),
+        shape = RoundedCornerShape(BUTTON_CORNER_RADIUS),
+        contentPadding = BUTTON_PADDING,
+        modifier =
+            modifier
+                .height(BUTTON_HEIGHT),
+    ) {
+        Text(
+            text = text,
+            color = textColor,
+            style = HY2Theme.typography.title03,
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun HY2DialogPreview() {
+    HY2Theme {
+        HY2Dialog(
+            description = "로그아웃 하실 건가요?",
+            leftButtonText = "돌아가기",
+            rightButtonText = "로그아웃하기",
+            onLeftButtonClick = { /* TODO */ },
+            onRightButtonClick = { /* TODO */ },
+            onDismiss = { /* TODO */ },
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
@@ -106,7 +106,6 @@ fun HY2Dialog(
 
 private val BUTTON_CORNER_RADIUS = 8.dp
 private val BUTTON_HEIGHT = 46.dp
-private val BUTTON_PADDING = PaddingValues(horizontal = 20.dp)
 
 @Composable
 private fun HY2DialogButton(
@@ -120,7 +119,7 @@ private fun HY2DialogButton(
         onClick = onClick,
         colors = ButtonDefaults.buttonColors(containerColor = buttonColor),
         shape = RoundedCornerShape(BUTTON_CORNER_RADIUS),
-        contentPadding = BUTTON_PADDING,
+        contentPadding = PaddingValues(horizontal = 20.dp),
         modifier =
             modifier
                 .height(BUTTON_HEIGHT),

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
@@ -45,6 +45,7 @@ fun HY2Dialog(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
     backgroundColor: Color = Gray800,
+    descriptionTextColor: Color = Gray100,
     leftButtonColor: Color = Blue100,
     rightButtonColor: Color = Gray600,
     leftButtonTextColor: Color = White,
@@ -73,7 +74,7 @@ fun HY2Dialog(
             ) {
                 Text(
                     text = description,
-                    color = Gray100,
+                    color = descriptionTextColor,
                     style = HY2Theme.typography.title02,
                     modifier = Modifier.padding(bottom = 16.dp),
                 )


### PR DESCRIPTION
resolved #9 

## AS-IS
재사용 가능성이 높아보이는 버튼이 두개 있는 다이얼로그를  

## TO-BE
디자인 시스템에 구현합니다.

## KEY-POINT
- 버튼 로직이 공통되는 부분이 많아 `HY2DialogButton`를 파일 분리하지 않고 내부에 정의하여 코드 가독성을 높혔습니다.
- 다이얼로그에만 사용되는 버튼이기 때문에 파일로 따로 분리하지 않았습니다.
- 상수화는 사이즈 관련 요소들만 하였습니다.
- `LocalConfiguration.current.screenWidthDp.dp`라는 신통방통한 놈을 사용해서 width값을 조정하였습니다.
- 보다 범용성 있는 다이얼로그 사용을 위해 button의 이름을 left와 right로 명명하였습니다. 오른쪽 버튼이 항상 enable or active 버튼이 아니기 때문입니다.
- button, text, background 색상은 기본값을 넣어두고 혹시나 색상이 다른 버전의 사용을 위해 인자로 열어두었습니다.
- back button을 눌렀을 때 dismiss 되는 속성은 true를 해두었고 밖을 누르는 것은 false를 해두었습니다.

## SCREENSHOT (Optional)
임시로 메인 엑티비티로 테스트 해보았습니다 (코드에는 테스트 코드가 없습니다)

https://github.com/user-attachments/assets/327f45ec-0b02-45b5-b515-a44a45ef771f

