### PR TITLE
[Feature] HY2WebView 공통 컴포넌트를 구현합니다.

### DIFF
--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2WebView.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2WebView.kt
@@ -11,7 +11,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -71,25 +73,33 @@ fun HY2WebViewHeader(
     Box(
         modifier =
             modifier
+                .height(52.dp)
                 .fillMaxWidth()
-                .background(backgroundColor)
-                .padding(vertical = 14.dp, horizontal = 28.dp),
+                .background(backgroundColor),
     ) {
         Text(
             text = titleText,
             style = HY2Theme.typography.title02,
             color = textColor,
-            modifier = Modifier.align(Alignment.Center),
+            modifier =
+                Modifier
+                    .align(Alignment.Center),
         )
-        Image(
-            painter = painterResource(id = R.drawable.ic_close),
-            contentDescription = stringResource(R.string.hy2_web_view_close_button),
-            colorFilter = androidx.compose.ui.graphics.ColorFilter.tint(iconColor),
+        Box(
             modifier =
                 Modifier
                     .align(Alignment.CenterEnd)
+                    .padding(end = 28.dp)
+                    .size(40.dp)
                     .clickable(onClick = onCloseButtonClick),
-        )
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_close),
+                contentDescription = stringResource(R.string.hy2_web_view_close_button),
+                colorFilter = androidx.compose.ui.graphics.ColorFilter.tint(iconColor),
+                modifier = Modifier.align(Alignment.Center),
+            )
+        }
     }
 }
 
@@ -98,19 +108,23 @@ fun HY2WebViewBody(
     url: String,
     modifier: Modifier = Modifier,
 ) {
-    AndroidView(
+    Box(
         modifier = modifier.fillMaxSize(),
-        factory = { context ->
-            WebView(context).apply {
-                settings.javaScriptEnabled = true
-                webViewClient = WebViewClient()
-                loadUrl(url)
-            }
-        },
-        update = { webView ->
-            webView.loadUrl(url)
-        },
-    )
+    ) {
+        AndroidView(
+            modifier = modifier.fillMaxSize(),
+            factory = { context ->
+                WebView(context).apply {
+                    settings.javaScriptEnabled = true
+                    webViewClient = WebViewClient()
+                    loadUrl(url)
+                }
+            },
+            update = { webView ->
+                webView.loadUrl(url)
+            },
+        )
+    }
 }
 
 @Preview(showBackground = true)

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2WebView.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2WebView.kt
@@ -1,0 +1,159 @@
+package com.teamhy2.designsystem.common
+
+import android.content.res.Configuration
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.teamhy2.designsystem.R
+import com.teamhy2.designsystem.ui.theme.Black
+import com.teamhy2.designsystem.ui.theme.HY2Theme
+import com.teamhy2.designsystem.ui.theme.White
+
+@Composable
+fun HY2WebViewHeader(
+    titleText: String,
+    onCloseButtonClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val isDarkTheme = isSystemInDarkTheme()
+    val backgroundColor = if (isDarkTheme) Black else White
+    val iconColor = if (isDarkTheme) White else Black
+    val textColor = if (isDarkTheme) White else Black
+
+    Box(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .background(backgroundColor)
+                .padding(vertical = 14.dp, horizontal = 28.dp),
+    ) {
+        Text(
+            text = titleText,
+            style = HY2Theme.typography.title02,
+            color = textColor,
+            modifier = Modifier.align(Alignment.Center),
+        )
+        Image(
+            painter = painterResource(id = R.drawable.ic_close),
+            contentDescription = stringResource(R.string.hy2_web_view_close_button),
+            colorFilter = androidx.compose.ui.graphics.ColorFilter.tint(iconColor),
+            modifier =
+                Modifier
+                    .align(Alignment.CenterEnd)
+                    .clickable(onClick = onCloseButtonClick),
+        )
+    }
+}
+
+@Composable
+fun HY2WebViewBody(
+    url: String,
+    modifier: Modifier = Modifier,
+) {
+    AndroidView(
+        modifier = modifier.fillMaxSize(),
+        factory = { context ->
+            WebView(context).apply {
+                settings.javaScriptEnabled = true
+                webViewClient = WebViewClient()
+                loadUrl(url)
+            }
+        },
+        update = { webView ->
+            webView.loadUrl(url)
+        },
+    )
+}
+
+@Composable
+fun HY2WebView(
+    titleText: String,
+    url: String,
+    onCloseButtonClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(if (isSystemInDarkTheme()) Black else White),
+    ) {
+        HY2WebViewHeader(
+            titleText = titleText,
+            onCloseButtonClick = onCloseButtonClick,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        HY2WebViewBody(
+            url = url,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HY2WebViewHeaderLightThemePreview() {
+    HY2Theme {
+        HY2WebViewHeader(
+            titleText = "좌석",
+            onCloseButtonClick = { },
+        )
+    }
+}
+
+@Preview(
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+private fun HY2WebViewHeaderDarkThemePreview() {
+    HY2Theme {
+        HY2WebViewHeader(
+            titleText = "좌석",
+            onCloseButtonClick = { },
+        )
+    }
+}
+
+// WebView javaScriptEnabled 활성화시 프리뷰가 보이지 않는 현상이 있습니다.
+@Preview(showBackground = true)
+@Composable
+private fun HY2WebViewBodyPreview() {
+    HY2Theme {
+        HY2WebViewBody(
+            url = "https://www.naver.com",
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HY2WebViewPreview() {
+    HY2Theme {
+        HY2WebView(
+            titleText = "좌석",
+            url = "https://www.naver.com",
+            onCloseButtonClick = { },
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2WebView.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2WebView.kt
@@ -27,12 +27,43 @@ import com.teamhy2.designsystem.ui.theme.HY2Theme
 import com.teamhy2.designsystem.ui.theme.White
 
 @Composable
-fun HY2WebViewHeader(
+fun HY2WebView(
     titleText: String,
+    url: String,
     onCloseButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val isDarkTheme = isSystemInDarkTheme()
+
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(if (isDarkTheme) Black else White),
+    ) {
+        HY2WebViewHeader(
+            titleText = titleText,
+            onCloseButtonClick = onCloseButtonClick,
+            isDarkTheme = isDarkTheme,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        HY2WebViewBody(
+            url = url,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+        )
+    }
+}
+
+@Composable
+fun HY2WebViewHeader(
+    titleText: String,
+    onCloseButtonClick: () -> Unit,
+    isDarkTheme: Boolean,
+    modifier: Modifier = Modifier,
+) {
     val backgroundColor = if (isDarkTheme) Black else White
     val iconColor = if (isDarkTheme) White else Black
     val textColor = if (isDarkTheme) White else Black
@@ -82,41 +113,16 @@ fun HY2WebViewBody(
     )
 }
 
-@Composable
-fun HY2WebView(
-    titleText: String,
-    url: String,
-    onCloseButtonClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier =
-            modifier
-                .fillMaxSize()
-                .background(if (isSystemInDarkTheme()) Black else White),
-    ) {
-        HY2WebViewHeader(
-            titleText = titleText,
-            onCloseButtonClick = onCloseButtonClick,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        HY2WebViewBody(
-            url = url,
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .weight(1f),
-        )
-    }
-}
-
 @Preview(showBackground = true)
 @Composable
 private fun HY2WebViewHeaderLightThemePreview() {
+    val isDarkTheme = isSystemInDarkTheme()
+
     HY2Theme {
         HY2WebViewHeader(
             titleText = "좌석",
             onCloseButtonClick = { },
+            isDarkTheme,
         )
     }
 }
@@ -127,10 +133,13 @@ private fun HY2WebViewHeaderLightThemePreview() {
 )
 @Composable
 private fun HY2WebViewHeaderDarkThemePreview() {
+    val isDarkTheme = isSystemInDarkTheme()
+
     HY2Theme {
         HY2WebViewHeader(
             titleText = "좌석",
             onCloseButtonClick = { },
+            isDarkTheme,
         )
     }
 }

--- a/core/designsystem/src/main/res/drawable/ic_close.xml
+++ b/core/designsystem/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="25dp"
+    android:height="24dp"
+    android:viewportWidth="25"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M18.1,18L6.1,6"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#23262D"
+      android:strokeLineCap="square"/>
+  <path
+      android:pathData="M18.1,6L6.1,18"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#23262D"
+      android:strokeLineCap="square"/>
+</vector>

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">designsystem</string>
+
+    <!-- HY2WebView -->
+    <string name="hy2_web_view_close_button">현재 화면을 닫을 수 있는 버튼입니다.</string>
 </resources>

--- a/main-presentation/src/main/AndroidManifest.xml
+++ b/main-presentation/src/main/AndroidManifest.xml
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-	<application>
-		<activity
-			android:name="com.teamhy2.feature.main.MainActivity"
-			android:exported="true"
-			android:theme="@style/Theme.HongikYeolgong2">
-			<intent-filter>
-				<action android:name="android.intent.action.MAIN" />
+    <uses-permission android:name="android.permission.INTERNET"/>
 
-				<category android:name="android.intent.category.LAUNCHER" />
-			</intent-filter>
-		</activity>
-	</application>
+    <application
+        android:usesCleartextTraffic="true"
+        android:theme="@style/Theme.HongikYeolgong2">
+
+        <activity
+            android:name="com.teamhy2.feature.main.MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
 
 </manifest>


### PR DESCRIPTION
resolved #24

## AS-IS
공지, 문의사항, 좌석 기능은 같은 형식의 웹뷰와 버튼을 가지고 있습니다.
공통 HY2WebView를 제작하여

## TO-BE
코드 재사용성을 증가시킵니다.

## KEY-POINT
- 다크모드에 대한 대응이 들어가 있습니다.
- WebView에  `settings.javaScriptEnabled = true` 속성을 활성화 시켜야 내부의 버튼을 클릭하는 JS 기능을 활용가능한데 이 속성을 활성화 시키면 프리뷰가 보이지 않는 현상이 있습니다. 

## SCREENSHOT (Optional)

https://github.com/user-attachments/assets/914d241e-7586-41a6-9633-a8e488156ee3

