### PR TITLE
[Feature] 공통 컴포넌트 텍스트 필드를 구현합니다.

### DIFF
--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2TextField.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2TextField.kt
@@ -53,9 +53,9 @@ fun HY2TextField(
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
     hintText: String = "",
-    errorText: String = "",
+    supportingText: String = "",
     isEnabled: Boolean = true,
-    isError: Boolean = false,
+    isInvalid: Boolean = false,
     keyboardType: KeyboardType = KeyboardType.Text,
     imeAction: ImeAction = ImeAction.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
@@ -71,13 +71,13 @@ fun HY2TextField(
             value = value,
             onValueChange = onValueChange,
             modifier =
-                modifier
-                    .background(
-                        color = Gray800,
-                        shape = RoundedCornerShape(DEFAULT_RADIUS.dp),
-                    )
-                    .height(48.dp)
-                    .fillMaxWidth(),
+            modifier
+                .background(
+                    color = Gray800,
+                    shape = RoundedCornerShape(DEFAULT_RADIUS.dp),
+                )
+                .height(48.dp)
+                .fillMaxWidth(),
             cursorBrush = SolidColor(Gray200),
             interactionSource = interactionSource,
             textStyle = HY2Typography().body05.copy(color = Gray200),
@@ -94,7 +94,7 @@ fun HY2TextField(
                 if (hasFocused) {
                     Modifier.border(
                         DEFAULT_BORDER_WIDTH.dp,
-                        if (isError) Yellow300 else borderColor,
+                        if (isInvalid) Yellow300 else borderColor,
                         RoundedCornerShape(DEFAULT_RADIUS.dp),
                     )
                 } else {
@@ -102,12 +102,12 @@ fun HY2TextField(
                 }
             Row(
                 modifier =
-                    modifierWithBorder
-                        .background(
-                            color = Gray800,
-                            shape = RoundedCornerShape(DEFAULT_RADIUS.dp),
-                        )
-                        .focusRequester(focusRequester),
+                modifierWithBorder
+                    .background(
+                        color = Gray800,
+                        shape = RoundedCornerShape(DEFAULT_RADIUS.dp),
+                    )
+                    .focusRequester(focusRequester),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Row(
@@ -140,7 +140,7 @@ fun HY2TextField(
         }
         Spacer(modifier = Modifier.height(4.dp))
         Text(
-            text = if (isError) errorText else "",
+            text = if (isInvalid) supportingText else "",
             style = HY2Typography().caption,
             color = Yellow300,
         )
@@ -167,8 +167,8 @@ private fun HY2TextFieldErrorPreview() {
         HY2TextField(
             value = "abc",
             onValueChange = {},
-            isError = true,
-            errorText = "*올바른 형식의 이름이 아닙니다",
+            isInvalid = true,
+            supportingText = "*올바른 형식의 이름이 아닙니다",
         )
     }
 }

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2TextField.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2TextField.kt
@@ -71,13 +71,13 @@ fun HY2TextField(
             value = value,
             onValueChange = onValueChange,
             modifier =
-            modifier
-                .background(
-                    color = Gray800,
-                    shape = RoundedCornerShape(DEFAULT_RADIUS.dp),
-                )
-                .height(48.dp)
-                .fillMaxWidth(),
+                modifier
+                    .background(
+                        color = Gray800,
+                        shape = RoundedCornerShape(DEFAULT_RADIUS.dp),
+                    )
+                    .height(48.dp)
+                    .fillMaxWidth(),
             cursorBrush = SolidColor(Gray200),
             interactionSource = interactionSource,
             textStyle = HY2Typography().body05.copy(color = Gray200),
@@ -102,12 +102,12 @@ fun HY2TextField(
                 }
             Row(
                 modifier =
-                modifierWithBorder
-                    .background(
-                        color = Gray800,
-                        shape = RoundedCornerShape(DEFAULT_RADIUS.dp),
-                    )
-                    .focusRequester(focusRequester),
+                    modifierWithBorder
+                        .background(
+                            color = Gray800,
+                            shape = RoundedCornerShape(DEFAULT_RADIUS.dp),
+                        )
+                        .focusRequester(focusRequester),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Row(
@@ -115,7 +115,7 @@ fun HY2TextField(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Spacer(modifier = Modifier.width(16.dp))
-                    if (!hasFocused && value.isBlank()) {
+                    if (hasFocused.not() && value.isBlank()) {
                         Text(
                             text = hintText,
                             style = MaterialTheme.typography.titleMedium,

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2TextField.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2TextField.kt
@@ -139,15 +139,11 @@ fun HY2TextField(
             }
         }
         Spacer(modifier = Modifier.height(4.dp))
-        Box {
-            if (isError) {
-                Text(
-                    text = errorText,
-                    style = HY2Typography().caption,
-                    color = Yellow300,
-                )
-            }
-        }
+        Text(
+            text = if (isError) errorText else "",
+            style = HY2Typography().caption,
+            color = Yellow300,
+        )
     }
 }
 

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2TextField.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2TextField.kt
@@ -1,0 +1,178 @@
+package com.teamhy2.designsystem.common
+
+import androidx.compose.animation.animateColor
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.teamhy2.designsystem.R
+import com.teamhy2.designsystem.ui.theme.Gray200
+import com.teamhy2.designsystem.ui.theme.Gray400
+import com.teamhy2.designsystem.ui.theme.Gray800
+import com.teamhy2.designsystem.ui.theme.HY2Theme
+import com.teamhy2.designsystem.ui.theme.HY2Typography
+import com.teamhy2.designsystem.ui.theme.Yellow300
+
+private const val DEFAULT_BORDER_WIDTH = 1
+private const val DEFAULT_RADIUS = 8
+
+@Composable
+fun HY2TextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    hintText: String = "",
+    errorText: String = "",
+    isEnabled: Boolean = true,
+    isError: Boolean = false,
+    keyboardType: KeyboardType = KeyboardType.Text,
+    imeAction: ImeAction = ImeAction.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val hasFocused by interactionSource.collectIsFocusedAsState()
+    val transition = updateTransition(hasFocused, label = "onHasFocused")
+    val borderColor by transition.animateColor(label = "borderColorTransition") { if (it) Gray400 else Gray800 }
+    val focusRequester = remember { FocusRequester() }
+
+    Column {
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier =
+                modifier
+                    .background(
+                        color = Gray800,
+                        shape = RoundedCornerShape(DEFAULT_RADIUS.dp),
+                    )
+                    .height(48.dp)
+                    .fillMaxWidth(),
+            cursorBrush = SolidColor(Gray200),
+            interactionSource = interactionSource,
+            textStyle = HY2Typography().body05.copy(color = Gray200),
+            keyboardOptions =
+                KeyboardOptions(
+                    keyboardType = keyboardType,
+                    imeAction = imeAction,
+                ),
+            keyboardActions = keyboardActions,
+            enabled = isEnabled,
+            singleLine = true,
+        ) { innerTextField ->
+            val modifierWithBorder =
+                if (hasFocused) {
+                    Modifier.border(
+                        DEFAULT_BORDER_WIDTH.dp,
+                        if (isError) Yellow300 else borderColor,
+                        RoundedCornerShape(DEFAULT_RADIUS.dp),
+                    )
+                } else {
+                    Modifier
+                }
+            Row(
+                modifier =
+                    modifierWithBorder
+                        .background(
+                            color = Gray800,
+                            shape = RoundedCornerShape(DEFAULT_RADIUS.dp),
+                        )
+                        .focusRequester(focusRequester),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(
+                    modifier = Modifier.weight(1f),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Spacer(modifier = Modifier.width(16.dp))
+                    if (!hasFocused && value.isBlank()) {
+                        Text(
+                            text = hintText,
+                            style = MaterialTheme.typography.titleMedium,
+                            color = Gray200,
+                        )
+                        Spacer(modifier = Modifier.weight(1f))
+                    } else {
+                        Box(modifier = Modifier.weight(1f)) {
+                            innerTextField()
+                        }
+                    }
+                    if (hasFocused && value.isNotBlank()) {
+                        IconButton(onClick = { onValueChange("") }) {
+                            Image(
+                                painter = painterResource(id = R.drawable.ic_all_remove),
+                                contentDescription = null,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        Box {
+            if (isError) {
+                Text(
+                    text = errorText,
+                    style = HY2Typography().caption,
+                    color = Yellow300,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun HY2TextFieldPreview() {
+    var value by remember { mutableStateOf("") }
+    HY2Theme {
+        HY2TextField(
+            value = value,
+            onValueChange = { value = it },
+            hintText = "입력해주세요.",
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun HY2TextFieldErrorPreview() {
+    HY2Theme {
+        HY2TextField(
+            value = "abc",
+            onValueChange = {},
+            isError = true,
+            errorText = "*올바른 형식의 이름이 아닙니다",
+        )
+    }
+}

--- a/core/designsystem/src/main/res/drawable/ic_all_remove.xml
+++ b/core/designsystem/src/main/res/drawable/ic_all_remove.xml
@@ -1,0 +1,23 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,21C16.971,21 21,16.971 21,12C21,7.029 16.971,3 12,3C7.029,3 3,7.029 3,12C3,16.971 7.029,21 12,21Z"
+      android:fillColor="#4F515A"/>
+  <path
+      android:pathData="M15,9L9,15"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#A5A8B0"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M9,9L15,15"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#A5A8B0"
+      android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
resolved #33 

## AS-IS
null

## TO-BE
공통 컴포넌트 텍스트 필드를 구현합니다.

## KEY-POINT
- 아마 다양한 버전의 텍스트 필드가 나올 수 있다보니 최대한 베이직하게 만드려고 노력하였습니다.
- 에러메시지의 유무에 따라 텍스트 필드의 크기가 달라지면 화면 구성시 어색할 거 같아, 에러메시지가 표시 되지 않더라도 공간을 차지하게끔 해보았습니다.
- 단톡방에 구두로 유림님께 부탁드렸던 텍스트 필드 핸들 색상 지정되면 그 때 변경 하여 커밋 후 pr 닫겠습니다.


## SCREENSHOT (Optional)
![hy2textfieldPreview](https://github.com/user-attachments/assets/a6381e0d-bf7a-4571-b614-6f84e41ae039)
![image](https://github.com/user-attachments/assets/738c27fe-fdff-4162-97b1-253fca5f9892)
