### PR TITLE
[Feature] MainScreen에 컴포넌트들을 배치하고 타이머 기능을 완성합니다.

### DIFF
--- a/main-presentation/src/main/java/com/teamhy2/feature/main/MainScreen.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/MainScreen.kt
@@ -33,7 +33,6 @@ import com.teamhy2.feature.main.model.MainUiState
 import com.teamhy2.hongikyeolgong2.main.presentation.R
 import com.teamhy2.hongikyeolgong2.timer.model.Timer
 import com.teamhy2.hongikyeolgong2.timer.prsentation.TimerViewModel
-import com.teamhy2.hongikyeolgong2.timer.prsentation.model.TimerUiModel
 import java.time.Duration
 import java.time.LocalTime
 import java.time.temporal.ChronoUnit
@@ -49,6 +48,8 @@ fun MainRoute(
 
     val timerViewModel: TimerViewModel = hiltViewModel()
     val timerState by timerViewModel.timerState.collectAsState()
+
+    mainViewModel.updateTimerStateFromTimerViewModel(timerState)
 
     if (uiState.isTimePickerVisible) {
         HY2TimePicker(
@@ -112,7 +113,6 @@ fun MainRoute(
 
     MainScreen(
         uiState = uiState,
-        timerState = timerState,
         modifier = modifier,
         onSettingClick = onSettingClick,
         onSeatingChartClick = onSeatingChartClick,
@@ -163,7 +163,6 @@ fun MainScreen(
     onStudyRoomEndClick: () -> Unit,
     modifier: Modifier = Modifier,
     uiState: MainUiState,
-    timerState: TimerUiModel,
 ) {
     Column(
         modifier =
@@ -188,7 +187,6 @@ fun MainScreen(
             onStudyRoomExtendClick = onStudyRoomExtendClick,
             onStudyRoomEndClick = onStudyRoomEndClick,
             uiState = uiState,
-            timerState = timerState,
             modifier = Modifier,
         )
     }
@@ -231,7 +229,6 @@ private fun MainBody(
     onStudyRoomExtendClick: () -> Unit,
     onStudyRoomEndClick: () -> Unit,
     uiState: MainUiState,
-    timerState: TimerUiModel,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -244,7 +241,9 @@ private fun MainBody(
         when (uiState.isTimerRunning) {
             true -> {
                 RunningTimerComponent(
-                    timerState = timerState,
+                    startTime = uiState.startTime,
+                    endTime = uiState.endTime,
+                    leftTime = uiState.leftTime,
                     onStudyRoomExtendClick = onStudyRoomExtendClick,
                     onStudyRoomEndClick = onStudyRoomEndClick,
                     modifier = Modifier.height(308.dp),
@@ -275,12 +274,6 @@ private fun MainBody(
 @Composable
 private fun MainScreenPreview() {
     val state = MainUiState()
-    val timerState =
-        TimerUiModel(
-            startTime = "11:30",
-            endTime = "12:00",
-            leftTime = "00:15:30",
-        )
 
     HY2Theme {
         MainScreen(
@@ -292,7 +285,6 @@ private fun MainScreenPreview() {
             onStudyRoomExtendClick = { },
             onStudyRoomEndClick = { },
             uiState = state,
-            timerState = timerState,
         )
     }
 }

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/MainScreen.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/MainScreen.kt
@@ -125,7 +125,7 @@ fun MainRoute(
             mainViewModel.updateStudyRoomExtendDialogVisibility(true)
         },
         onStudyRoomEndClick = {
-            mainViewModel.updateStudyRoomExtendDialogVisibility(true)
+            mainViewModel.updateStudyRoomEndDialogVisibility(true)
         },
     )
 }
@@ -189,7 +189,7 @@ fun MainScreen(
             onStudyRoomEndClick = onStudyRoomEndClick,
             uiState = uiState,
             timerState = timerState,
-            modifier = Modifier.padding(bottom = 36.dp),
+            modifier = Modifier,
         )
     }
 }
@@ -260,12 +260,13 @@ private fun MainBody(
                 )
             }
         }
-        Spacer(modifier = Modifier.height(34.dp))
+        Spacer(modifier = Modifier.weight(1f))
         Hy2Calendar(
             title = uiState.calendar.now,
             days = uiState.calendar.getMonth(),
             onPreviousMonthClick = onPreviousMonthClick,
             onNextMonthClick = onNextMonthClick,
+            modifier = Modifier.padding(bottom = 24.dp),
         )
     }
 }

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/MainScreen.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/MainScreen.kt
@@ -187,7 +187,6 @@ fun MainScreen(
             onStudyRoomExtendClick = onStudyRoomExtendClick,
             onStudyRoomEndClick = onStudyRoomEndClick,
             uiState = uiState,
-            modifier = Modifier,
         )
     }
 }

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/MainScreen.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/MainScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.hongikyeolgong2.calendar.presentation.Hy2Calendar
+import com.teamhy2.designsystem.common.HY2Dialog
 import com.teamhy2.designsystem.common.HY2TimePicker
 import com.teamhy2.designsystem.ui.theme.Black
 import com.teamhy2.designsystem.ui.theme.Gray100
@@ -69,6 +70,46 @@ fun MainRoute(
         )
     }
 
+    if (uiState.isStudyRoomExtendDialog) {
+        HY2Dialog(
+            description = stringResource(R.string.main_extend_dialog_title),
+            leftButtonText = stringResource(R.string.main_extend_dialog_negative_button),
+            rightButtonText = stringResource(R.string.main_extend_dialog_postitive_button),
+            onLeftButtonClick = {
+                mainViewModel.updateStudyRoomExtendDialogVisibility(false)
+            },
+            onRightButtonClick = {
+                mainViewModel.updateStudyRoomExtendDialogVisibility(false)
+                mainViewModel.updateTimerRunning(false)
+            },
+            onDismiss = {
+                mainViewModel.updateStudyRoomExtendDialogVisibility(false)
+            },
+        )
+    }
+
+    if (uiState.isStudyRoomEndDialog) {
+        HY2Dialog(
+            description = stringResource(R.string.main_end_dialog_title),
+            leftButtonText = stringResource(R.string.main_end_dialog_negative_button),
+            rightButtonText = stringResource(R.string.main_end_dialog_positive_button),
+            onLeftButtonClick = {
+                mainViewModel.updateStudyRoomEndDialogVisibility(false)
+            },
+            onRightButtonClick = {
+                mainViewModel.updateStudyRoomEndDialogVisibility(false)
+                startTimer(
+                    LocalTime.now().truncatedTo(ChronoUnit.MINUTES),
+                    mainViewModel,
+                    timerViewModel,
+                )
+            },
+            onDismiss = {
+                mainViewModel.updateStudyRoomEndDialogVisibility(false)
+            },
+        )
+    }
+
     MainScreen(
         uiState = uiState,
         timerState = timerState,
@@ -78,16 +119,14 @@ fun MainRoute(
         onStudyRoomStartClick = {
             mainViewModel.updateTimePickerVisibility(true)
         },
-        onPreviousMonthClick = { mainViewModel.updateCalendarMonth(isNextMonth = false) },
-        onNextMonthClick = { mainViewModel.updateCalendarMonth(isNextMonth = true) },
+        onPreviousMonthClick = { mainViewModel.updateCalendarMonth(false) },
+        onNextMonthClick = { mainViewModel.updateCalendarMonth(true) },
         onStudyRoomExtendClick = {
-            startTimer(
-                LocalTime.now().truncatedTo(ChronoUnit.MINUTES),
-                mainViewModel,
-                timerViewModel,
-            )
+            mainViewModel.updateStudyRoomExtendDialogVisibility(true)
         },
-        onStudyRoomEndClick = { mainViewModel.updateTimerRunning(false) },
+        onStudyRoomEndClick = {
+            mainViewModel.updateStudyRoomExtendDialogVisibility(true)
+        },
     )
 }
 

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/MainScreen.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/MainScreen.kt
@@ -75,13 +75,17 @@ fun MainRoute(
         HY2Dialog(
             description = stringResource(R.string.main_extend_dialog_title),
             leftButtonText = stringResource(R.string.main_extend_dialog_negative_button),
-            rightButtonText = stringResource(R.string.main_extend_dialog_postitive_button),
+            rightButtonText = stringResource(R.string.main_extend_dialog_positive_button),
             onLeftButtonClick = {
                 mainViewModel.updateStudyRoomExtendDialogVisibility(false)
             },
             onRightButtonClick = {
                 mainViewModel.updateStudyRoomExtendDialogVisibility(false)
-                mainViewModel.updateTimerRunning(false)
+                startTimer(
+                    LocalTime.now().truncatedTo(ChronoUnit.MINUTES),
+                    mainViewModel,
+                    timerViewModel,
+                )
             },
             onDismiss = {
                 mainViewModel.updateStudyRoomExtendDialogVisibility(false)
@@ -99,11 +103,7 @@ fun MainRoute(
             },
             onRightButtonClick = {
                 mainViewModel.updateStudyRoomEndDialogVisibility(false)
-                startTimer(
-                    LocalTime.now().truncatedTo(ChronoUnit.MINUTES),
-                    mainViewModel,
-                    timerViewModel,
-                )
+                mainViewModel.updateTimerRunning(false)
             },
             onDismiss = {
                 mainViewModel.updateStudyRoomEndDialogVisibility(false)

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/MainViewModel.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/MainViewModel.kt
@@ -97,6 +97,14 @@ class MainViewModel
             _mainUiState.value = mainUiState.value.copy(selectedTime = selectedTime)
         }
 
+        fun updateStudyRoomExtendDialogVisibility(isVisible: Boolean) {
+            _mainUiState.value = mainUiState.value.copy(isStudyRoomExtendDialog = isVisible)
+        }
+
+        fun updateStudyRoomEndDialogVisibility(isVisible: Boolean) {
+            _mainUiState.value = mainUiState.value.copy(isStudyRoomEndDialog = isVisible)
+        }
+
         fun updateCalendarMonth(isNextMonth: Boolean) {
             val updatedCalendar =
                 mainUiState.value.calendar.apply {

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/MainViewModel.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/MainViewModel.kt
@@ -9,6 +9,7 @@ import com.hongikyeolgong2.calendar.model.Calendar
 import com.hongikyeolgong2.calendar.model.StudyDay
 import com.hongikyeolgong2.calendar.model.StudyRoomUsage
 import com.teamhy2.feature.main.model.MainUiState
+import com.teamhy2.hongikyeolgong2.timer.prsentation.model.TimerUiModel
 import com.teamhy2.main.domain.WebViewRepository
 import com.teamhy2.main.domain.WiseSayingRepository
 import com.teamhy2.onboarding.domain.repository.UserRepository
@@ -115,5 +116,14 @@ class MainViewModel
                     }
                 }
             _mainUiState.value = mainUiState.value.copy(calendar = updatedCalendar)
+        }
+
+        fun updateTimerStateFromTimerViewModel(timerState: TimerUiModel) {
+            _mainUiState.value =
+                _mainUiState.value.copy(
+                    startTime = timerState.startTime,
+                    endTime = timerState.endTime,
+                    leftTime = timerState.leftTime,
+                )
         }
     }

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/component/BackgroundImageButton.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/component/BackgroundImageButton.kt
@@ -21,7 +21,7 @@ import com.teamhy2.designsystem.ui.theme.HY2Typography
 import com.teamhy2.hongikyeolgong2.main.presentation.R
 
 @Composable
-fun MainImageButton(
+fun BackgroundImageButton(
     imageResId: Int,
     text: String,
     onClick: () -> Unit,
@@ -52,8 +52,8 @@ fun MainImageButton(
 
 @Preview(showBackground = true)
 @Composable
-fun MainImageButtonPreview() {
-    MainImageButton(
+fun BackgroundImageButtonPreview() {
+    BackgroundImageButton(
         imageResId = R.drawable.img_seating_chart_button_background,
         text = "좌석",
         onClick = { },

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/component/InitTimerComponent.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/component/InitTimerComponent.kt
@@ -44,14 +44,14 @@ fun InitTimerComponent(
                     .height(BUTTON_HEIGHT.dp)
                     .fillMaxWidth(),
         ) {
-            MainImageButton(
+            BackgroundImageButton(
                 imageResId = R.drawable.img_seating_chart_button_background,
                 text = stringResource(R.string.main_seating_chart),
                 onClick = onSeatingChartClick,
                 modifier = Modifier.weight(70f),
             )
             Spacer(modifier = Modifier.weight(12f))
-            MainImageButton(
+            BackgroundImageButton(
                 imageResId = R.drawable.img_study_room_start_button_background,
                 text = stringResource(R.string.main_start_study_room),
                 onClick = onStudyRoomStartClick,

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/component/RunningTimerComponent.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/component/RunningTimerComponent.kt
@@ -16,11 +16,12 @@ import com.teamhy2.designsystem.ui.theme.Gray600
 import com.teamhy2.designsystem.ui.theme.HY2Theme
 import com.teamhy2.hongikyeolgong2.main.presentation.R
 import com.teamhy2.hongikyeolgong2.timer.prsentation.HY2Timer
-import com.teamhy2.hongikyeolgong2.timer.prsentation.model.TimerUiModel
 
 @Composable
 fun RunningTimerComponent(
-    timerState: TimerUiModel,
+    startTime: String,
+    endTime: String,
+    leftTime: String,
     onStudyRoomExtendClick: () -> Unit,
     onStudyRoomEndClick: () -> Unit,
     extendThreshold: String = "00:30:00",
@@ -31,13 +32,13 @@ fun RunningTimerComponent(
     ) {
         Spacer(modifier = Modifier.height(20.dp))
         HY2Timer(
-            leftTime = timerState.leftTime,
-            startTime = timerState.startTime,
-            endTime = timerState.endTime,
+            leftTime = leftTime,
+            startTime = startTime,
+            endTime = endTime,
         )
         Spacer(modifier = Modifier.height(16.dp))
 
-        if (timerState.leftTime <= extendThreshold) {
+        if (leftTime <= extendThreshold) {
             HY2Button(
                 text = stringResource(R.string.main_extend_study_room),
                 onClick = onStudyRoomExtendClick,
@@ -57,16 +58,11 @@ fun RunningTimerComponent(
 @Preview(showBackground = true)
 @Composable
 fun TimerScreenPreview_LessThanExtendThreshold() {
-    val dummyTimerState =
-        TimerUiModel(
+    HY2Theme {
+        RunningTimerComponent(
             startTime = "11:30",
             endTime = "12:00",
             leftTime = "00:14:03",
-        )
-
-    HY2Theme {
-        RunningTimerComponent(
-            timerState = dummyTimerState,
             onStudyRoomExtendClick = { },
             onStudyRoomEndClick = { },
             modifier = Modifier.background(Black),
@@ -77,16 +73,11 @@ fun TimerScreenPreview_LessThanExtendThreshold() {
 @Preview(showBackground = true)
 @Composable
 fun TimerScreenPreview_MoreThanExtendThreshold() {
-    val dummyTimerState =
-        TimerUiModel(
+    HY2Theme {
+        RunningTimerComponent(
             startTime = "11:30",
             endTime = "12:00",
             leftTime = "00:45:00",
-        )
-
-    HY2Theme {
-        RunningTimerComponent(
-            timerState = dummyTimerState,
             onStudyRoomExtendClick = { },
             onStudyRoomEndClick = { },
             modifier = Modifier.background(Black),

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/model/MainUiState.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/model/MainUiState.kt
@@ -1,7 +1,6 @@
 package com.teamhy2.feature.main.model
 
 import com.hongikyeolgong2.calendar.model.Calendar
-import com.teamhy2.hongikyeolgong2.timer.prsentation.model.TimerUiModel
 import com.teamhy2.main.model.WiseSaying
 import java.time.LocalTime
 
@@ -13,5 +12,7 @@ data class MainUiState(
     val wiseSaying: WiseSaying = WiseSaying("", ""),
     val selectedTime: LocalTime = LocalTime.now(),
     val calendar: Calendar = Calendar(studyDays = emptyList()),
-    val timerState: TimerUiModel = TimerUiModel(),
+    val startTime: String = "",
+    val endTime: String = "",
+    val leftTime: String = "",
 )

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/model/MainUiState.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/model/MainUiState.kt
@@ -8,6 +8,8 @@ import java.time.LocalTime
 data class MainUiState(
     val isTimerRunning: Boolean = false,
     val isTimePickerVisible: Boolean = false,
+    val isStudyRoomExtendDialog: Boolean = false,
+    val isStudyRoomEndDialog: Boolean = false,
     val wiseSaying: WiseSaying = WiseSaying("", ""),
     val selectedTime: LocalTime = LocalTime.now(),
     val calendar: Calendar = Calendar(studyDays = emptyList()),

--- a/main-presentation/src/main/res/values/strings.xml
+++ b/main-presentation/src/main/res/values/strings.xml
@@ -8,12 +8,12 @@
     <string name="main_end_study_room">열람실 이용 종료</string>
     <string name="main_study_room_use_start_time">열람실 이용 시간</string>
     <string name="main_seating_chart">좌석</string>
-    <string name="main_extend_dialog_title">열람실을 다 이용하셨나요?</string>
-    <string name="main_extend_dialog_negative_button">더 이용하기</string>
-    <string name="main_extend_dialog_postitive_button">네</string>
-    <string name="main_end_dialog_title">열람실 이용 시간을 연장할까요?</string>
-    <string name="main_end_dialog_negative_button">아니오</string>
-    <string name="main_end_dialog_positive_button">연장하기</string>
+    <string name="main_end_dialog_title">열람실을 다 이용하셨나요?</string>
+    <string name="main_end_dialog_negative_button">더 이용하기</string>
+    <string name="main_end_dialog_positive_button">네</string>
+    <string name="main_extend_dialog_title">열람실 이용 시간을 연장할까요?</string>
+    <string name="main_extend_dialog_negative_button">아니오</string>
+    <string name="main_extend_dialog_positive_button">연장하기</string>
 
     <!-- webViews -->
     <string name="inquiry_title">문의</string>

--- a/main-presentation/src/main/res/values/strings.xml
+++ b/main-presentation/src/main/res/values/strings.xml
@@ -8,6 +8,12 @@
     <string name="main_end_study_room">열람실 이용 종료</string>
     <string name="main_study_room_use_start_time">열람실 이용 시간</string>
     <string name="main_seating_chart">좌석</string>
+    <string name="main_extend_dialog_title">열람실을 다 이용하셨나요?</string>
+    <string name="main_extend_dialog_negative_button">더 이용하기</string>
+    <string name="main_extend_dialog_postitive_button">네</string>
+    <string name="main_end_dialog_title">열람실 이용 시간을 연장할까요?</string>
+    <string name="main_end_dialog_negative_button">아니오</string>
+    <string name="main_end_dialog_positive_button">연장하기</string>
 
     <!-- webViews -->
     <string name="inquiry_title">문의</string>


### PR DESCRIPTION
resolved #42 

## AS-IS
이전 작업까지 MainScreen의 컴포넌트들을 분리해서 제작하였습니다. 

## TO-BE
분리해서 작업한 컴포넌트들을 MainScreen에 적용하고 타이머 기능이 자연스럽게 작동하도록 구현합니다.

## KEY-POINT
- 캘린더 기능은 회원가입 로직이 붙고 작업하면 좋을 것 같아 구색만 맞춰두었습니다.
- 작업을 하다보니 Timer 피처의 UiModel이 필요할 것 같아 추가하였습니다.
- 타임피커의 기본 높이를 줘서 갑자기 생기는 느낌을 없앨 수 있으면 더 좋을 것 같습니다!
- 더 높은 퀄리티를 내고 싶었었는데 구현에 일단 집중하였습니다! 모든 피드백 감사하게 받겠습니다!

## SCREENSHOT (Optional)
https://github.com/user-attachments/assets/53e92ae2-32a4-4ab3-873d-3493bf0a2b8f

