### PR TITLE
[Feature] 타이머를 종료할 때 StudyDay 기록을 firebase에 전송합니다.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">HongikYeolgong2</string>
+    <string name="app_name">홍익열공이</string>
 </resources>

--- a/core/designsystem/src/main/res/values/themes.xml
+++ b/core/designsystem/src/main/res/values/themes.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="Theme.HongikYeolgong2" parent="Theme.AppCompat.DayNight.NoActionBar" />
+    <style name="Theme.HongikYeolgong2" parent="Theme.AppCompat.DayNight.NoActionBar">
+        <item name="android:windowSplashScreenBackground" tools:ignore="NewApi">#0C0D11</item>
+    </style>
 </resources>

--- a/main-data/src/main/java/com/teamhy2/main/data/di/MainModule.kt
+++ b/main-data/src/main/java/com/teamhy2/main/data/di/MainModule.kt
@@ -1,7 +1,9 @@
 package com.teamhy2.main.data.di
 
+import com.teamhy2.main.data.repository.DefaultStudyDayRepository
 import com.teamhy2.main.data.repository.DefaultWebViewRepository
 import com.teamhy2.main.data.repository.DefaultWiseSayingRepository
+import com.teamhy2.main.domain.StudyDayRepository
 import com.teamhy2.main.domain.WebViewRepository
 import com.teamhy2.main.domain.WiseSayingRepository
 import dagger.Binds
@@ -20,4 +22,8 @@ abstract class MainModule {
     @Binds
     @Singleton
     abstract fun bindWiseSayingRepository(impl: DefaultWiseSayingRepository): WiseSayingRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindStudyDayRepository(impl: DefaultStudyDayRepository): StudyDayRepository
 }

--- a/main-data/src/main/java/com/teamhy2/main/data/repository/DefaultStudyDayRepository.kt
+++ b/main-data/src/main/java/com/teamhy2/main/data/repository/DefaultStudyDayRepository.kt
@@ -1,5 +1,7 @@
 package com.teamhy2.main.data.repository
 
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
 import com.teamhy2.main.domain.StudyDayRepository
 import com.teamhy2.main.model.StudyDay
@@ -27,7 +29,7 @@ class DefaultStudyDayRepository
                 startTimeParsed = startTimeParsed.minusDays(1)
             }
 
-            val duration = ChronoUnit.SECONDS.between(startTimeParsed, now)
+            val duration: Long = ChronoUnit.SECONDS.between(startTimeParsed, now)
 
             val studyDay =
                 StudyDay(
@@ -35,8 +37,10 @@ class DefaultStudyDayRepository
                     secondDuration = duration,
                 )
 
-            val userDocRef = firestore.collection(USERS_COLLECTION).document(uid)
-            val studyDayCollection = userDocRef.collection(STUDYDAY_COLLECTION)
+            val userDocumentReference: DocumentReference =
+                firestore.collection(USERS_COLLECTION).document(uid)
+            val studyDayCollection: CollectionReference =
+                userDocumentReference.collection(STUDYDAY_COLLECTION)
             studyDayCollection.add(studyDay.toMap()).await()
         }
 

--- a/main-data/src/main/java/com/teamhy2/main/data/repository/DefaultStudyDayRepository.kt
+++ b/main-data/src/main/java/com/teamhy2/main/data/repository/DefaultStudyDayRepository.kt
@@ -27,12 +27,12 @@ class DefaultStudyDayRepository
                 startTimeParsed = startTimeParsed.minusDays(1)
             }
 
-            val duration = ChronoUnit.MINUTES.between(startTimeParsed, now)
+            val duration = ChronoUnit.SECONDS.between(startTimeParsed, now)
 
             val studyDay =
                 StudyDay(
                     date = LocalDate.now(),
-                    minuteDuration = duration,
+                    secondDuration = duration,
                 )
 
             val userDocRef = firestore.collection(USERS_COLLECTION).document(uid)

--- a/main-data/src/main/java/com/teamhy2/main/data/repository/DefaultStudyDayRepository.kt
+++ b/main-data/src/main/java/com/teamhy2/main/data/repository/DefaultStudyDayRepository.kt
@@ -1,0 +1,47 @@
+package com.teamhy2.main.data.repository
+
+import com.google.firebase.firestore.FirebaseFirestore
+import com.teamhy2.main.domain.StudyDayRepository
+import com.teamhy2.main.model.StudyDay
+import com.teamhy2.main.model.toMap
+import kotlinx.coroutines.tasks.await
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.temporal.ChronoUnit
+import javax.inject.Inject
+
+class DefaultStudyDayRepository
+    @Inject
+    constructor() : StudyDayRepository {
+        private val firestore = FirebaseFirestore.getInstance()
+
+        override suspend fun addStudyDay(
+            uid: String,
+            startTime: String,
+        ) {
+            val now = LocalDateTime.now()
+            var startTimeParsed = LocalDateTime.of(now.toLocalDate(), LocalTime.parse(startTime))
+
+            if (startTimeParsed.isAfter(now)) {
+                startTimeParsed = startTimeParsed.minusDays(1)
+            }
+
+            val duration = ChronoUnit.MINUTES.between(startTimeParsed, now)
+
+            val studyDay =
+                StudyDay(
+                    date = LocalDate.now(),
+                    minuteDuration = duration,
+                )
+
+            val userDocRef = firestore.collection(USERS_COLLECTION).document(uid)
+            val studyDayCollection = userDocRef.collection(STUDYDAY_COLLECTION)
+            studyDayCollection.add(studyDay.toMap()).await()
+        }
+
+        companion object {
+            private const val USERS_COLLECTION = "User"
+            private const val STUDYDAY_COLLECTION = "StudyDay"
+        }
+    }

--- a/main-domain/src/main/java/com/teamhy2/main/domain/StudyDayRepository.kt
+++ b/main-domain/src/main/java/com/teamhy2/main/domain/StudyDayRepository.kt
@@ -1,0 +1,8 @@
+package com.teamhy2.main.domain
+
+interface StudyDayRepository {
+    suspend fun addStudyDay(
+        uid: String,
+        startTime: String,
+    )
+}

--- a/main-domain/src/main/java/com/teamhy2/main/model/StudyDay.kt
+++ b/main-domain/src/main/java/com/teamhy2/main/model/StudyDay.kt
@@ -4,12 +4,12 @@ import java.time.LocalDate
 
 data class StudyDay(
     val date: LocalDate,
-    val minuteDuration: Long,
+    val secondDuration: Long,
 )
 
 fun StudyDay.toMap(): Map<String, Any> {
     return mapOf(
         "date" to this.date.toString(),
-        "minuteDuration" to this.minuteDuration,
+        "secondDuration" to this.secondDuration,
     )
 }

--- a/main-domain/src/main/java/com/teamhy2/main/model/StudyDay.kt
+++ b/main-domain/src/main/java/com/teamhy2/main/model/StudyDay.kt
@@ -1,0 +1,15 @@
+package com.teamhy2.main.model
+
+import java.time.LocalDate
+
+data class StudyDay(
+    val date: LocalDate,
+    val minuteDuration: Long,
+)
+
+fun StudyDay.toMap(): Map<String, Any> {
+    return mapOf(
+        "date" to this.date.toString(),
+        "minuteDuration" to this.minuteDuration,
+    )
+}

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/MainScreen.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/MainScreen.kt
@@ -107,6 +107,7 @@ fun MainRoute(
             onRightButtonClick = {
                 mainViewModel.updateStudyRoomEndDialogVisibility(false)
                 mainViewModel.updateTimerRunning(false)
+                mainViewModel.addStudyDay()
             },
             onDismiss = {
                 mainViewModel.updateStudyRoomEndDialogVisibility(false)

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/MainViewModel.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/MainViewModel.kt
@@ -5,12 +5,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
 import com.hongikyeolgong2.calendar.model.Calendar
 import com.hongikyeolgong2.calendar.model.StudyDay
 import com.hongikyeolgong2.calendar.model.StudyRoomUsage
 import com.teamhy2.feature.main.model.MainUiState
 import com.teamhy2.hongikyeolgong2.notification.NotificationHandler
 import com.teamhy2.hongikyeolgong2.timer.prsentation.model.TimerUiModel
+import com.teamhy2.main.domain.StudyDayRepository
 import com.teamhy2.main.domain.WebViewRepository
 import com.teamhy2.main.domain.WiseSayingRepository
 import com.teamhy2.onboarding.domain.repository.UserRepository
@@ -30,6 +33,7 @@ class MainViewModel
         private val webViewRepository: WebViewRepository,
         private val wiseSayingRepository: WiseSayingRepository,
         private val userRepository: UserRepository,
+        private val studyDayRepository: StudyDayRepository,
         val notificationHandler: NotificationHandler,
     ) : ViewModel() {
         private val _mainUiState = MutableStateFlow(MainUiState())
@@ -37,6 +41,10 @@ class MainViewModel
 
         var urls by mutableStateOf<Map<String, String>>(emptyMap())
             private set
+
+        val userUid: String by lazy {
+            Firebase.auth.currentUser?.uid ?: ""
+        }
 
         private val _userExists: MutableStateFlow<Boolean> = MutableStateFlow(true)
         val userExists: StateFlow<Boolean> = _userExists.asStateFlow()
@@ -127,5 +135,16 @@ class MainViewModel
                     endTime = timerState.endTime,
                     leftTime = timerState.leftTime,
                 )
+        }
+
+        fun addStudyDay() {
+            val uid = userUid
+            val startTime = mainUiState.value.startTime
+
+            if (uid.isNotEmpty() && startTime != null) {
+                viewModelScope.launch {
+                    studyDayRepository.addStudyDay(uid, startTime)
+                }
+            }
         }
     }


### PR DESCRIPTION
resolved #50 

## AS-IS
X

## TO-BE
- 사용자별 StudyDay 컬렉션에 공부 기록을 전송할 수 있습니다.

## KEY-POINT

타이머를 종료할 때 (아래의 두 개의 케이스)
1. 사용자가 "열람실 이용 종료"를 눌렀을 때
2. 타이머가 이용 시간을 다 사용하여 종료 되었을 때

공부 날짜와 공부 시간을 사용자별 StudyDay 컬렉션에 문서로 생성합니다. (아래 생성된 문서의 모습입니다.)

<img width="971" alt="스크린샷 2024-08-29 오후 3 52 59" src="https://github.com/user-attachments/assets/e094abe7-4073-49b7-9e36-8b13e80bea09">

## SCREENSHOT (Optional)