### PR TITLE
[Fix] 공부를 4회 이상 진행한 경우 캘린더에 0회로 표기되는 현상을 해결합니다.

### DIFF
--- a/main-presentation/src/main/java/com/teamhy2/feature/main/mapper/StudyDayMapper.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/mapper/StudyDayMapper.kt
@@ -12,10 +12,11 @@ object StudyDayMapper {
 
     private fun mapToStudyRoomUsage(studyStartTimesCount: Int): StudyRoomUsage {
         return when (studyStartTimesCount) {
+            0 -> StudyRoomUsage.NEVER_USED
             1 -> StudyRoomUsage.USED_ONCE
             2 -> StudyRoomUsage.USED_ONCE_EXTENDED_ONCE
             3 -> StudyRoomUsage.USED_ONCE_EXTENDED_TWICE
-            else -> StudyRoomUsage.NEVER_USED
+            else -> StudyRoomUsage.USED_ONCE_EXTENDED_TWICE
         }
     }
 


### PR DESCRIPTION
resolved #64 

## AS-IS
- 사용자가 4회 이상 공부를 한 경우 캘린더에서 0회 공부한 것으로 보는 현상이 발생합니다.

## TO-BE
- mapper를 수정하여 잘못된 로직을 수정합니다.

## KEY-POINT
x

## SCREENSHOT (Optional)
