### PR TITLE
[Feature] 주간 캘린더 컴포넌트를 구현

### DIFF
--- a/main-presentation/src/main/java/com/teamhy2/feature/main/component/StarsComponent.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/component/StarsComponent.kt
@@ -30,7 +30,7 @@ fun StarsComponent(
 }
 
 @Composable
-fun getStarPainter(
+private fun getStarPainter(
     starCount: Int,
     position: Int,
 ): Painter {

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/component/WeeklyCalendar.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/component/WeeklyCalendar.kt
@@ -61,7 +61,7 @@ private fun isDateInFuture(
 
 @Preview(showBackground = true)
 @Composable
-fun PreviewWeeklyCalendar() {
+private fun PreviewWeeklyCalendar() {
     val thisWeeksDates = getThisWeeksDates()
     HY2Theme {
         WeeklyCalendar(

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/component/WeeklyCalendar.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/component/WeeklyCalendar.kt
@@ -25,14 +25,13 @@ fun WeeklyCalendar(
     dates: List<String>,
     modifier: Modifier = Modifier,
 ) {
-    val daysOfWeek = DAYS_OF_WEEK
     val currentDate = LocalDate.now()
 
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.Center,
     ) {
-        daysOfWeek.forEachIndexed { index, dayOfWeek ->
+        DAYS_OF_WEEK.forEachIndexed { index, dayOfWeek ->
             val date = dates.getOrElse(index) { "" }
             val isFutureDate = isDateInFuture(date, currentDate)
 

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/component/WeeklyCalendar.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/component/WeeklyCalendar.kt
@@ -15,6 +15,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoField
 import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalAccessor
 
 private val DAYS_OF_WEEK = listOf("월", "화", "수", "목", "금", "토", "일")
 private const val DATE_FORMAT_PATTERN = "M/d"
@@ -49,11 +50,11 @@ private fun isDateInFuture(
     dateText: String,
     currentDate: LocalDate,
 ): Boolean {
-    val formatter = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN)
-    val parsedMonthDay = formatter.parse(dateText)
-    val month = parsedMonthDay[ChronoField.MONTH_OF_YEAR]
-    val day = parsedMonthDay[ChronoField.DAY_OF_MONTH]
-    val parsedDate = LocalDate.of(currentDate.year, month, day)
+    val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN)
+    val parsedMonthDay: TemporalAccessor = formatter.parse(dateText)
+    val month: Int = parsedMonthDay[ChronoField.MONTH_OF_YEAR]
+    val day: Int = parsedMonthDay[ChronoField.DAY_OF_MONTH]
+    val parsedDate: LocalDate = LocalDate.of(currentDate.year, month, day)
 
     return parsedDate.isAfter(currentDate)
 }

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/component/WeeklyCalendar.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/component/WeeklyCalendar.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.teamhy2.designsystem.ui.theme.Gray400
 import com.teamhy2.designsystem.ui.theme.HY2Theme
 import com.teamhy2.designsystem.ui.theme.White
+import com.teamhy2.feature.main.model.WeeklyDay
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoField
@@ -22,8 +23,7 @@ private const val DATE_FORMAT_PATTERN = "M/d"
 
 @Composable
 fun WeeklyCalendar(
-    studyCounts: List<Int>,
-    dates: List<String>,
+    weeklyDays: List<WeeklyDay>,
     modifier: Modifier = Modifier,
 ) {
     val currentDate = LocalDate.now()
@@ -33,13 +33,12 @@ fun WeeklyCalendar(
         horizontalArrangement = Arrangement.Center,
     ) {
         DAYS_OF_WEEK.forEachIndexed { index, dayOfWeek ->
-            val date = dates.getOrElse(index) { "" }
-            val isFutureDate = isDateInFuture(date, currentDate)
+            val isFutureDate = isDateInFuture(weeklyDays[index].date, currentDate)
 
             WeeklyDayComponent(
                 dayOfWeek = dayOfWeek,
-                studyCount = studyCounts.getOrElse(index) { 0 },
-                date = date,
+                studyCount = weeklyDays[index].studyCount,
+                date = weeklyDays[index].date,
                 textColor = if (isFutureDate) Gray400 else White,
             )
         }
@@ -62,22 +61,25 @@ private fun isDateInFuture(
 @Preview(showBackground = true)
 @Composable
 private fun PreviewWeeklyCalendar() {
-    val thisWeeksDates = getThisWeeksDates()
+    val thisWeeksDates: List<String> = getThisWeeksDates()
+    val weeklyDays =
+        thisWeeksDates.mapIndexed { index, date ->
+            WeeklyDay(
+                studyCount = listOf(3, 1, 2, 0, 0, 0, 0).getOrElse(index) { 0 },
+                date = date,
+            )
+        }
+
     HY2Theme {
         WeeklyCalendar(
-            studyCounts = listOf(3, 1, 2, 0, 0, 0, 0),
-            dates = thisWeeksDates,
-            modifier =
-                Modifier
-                    .background(Color.Black),
+            weeklyDays = weeklyDays,
+            modifier = Modifier.background(Color.Black),
         )
     }
 }
 
-private fun getThisWeeksDates(): List<String> {
-    val today = LocalDate.now()
-    val startOfWeek =
-        today.with(ChronoUnit.DAYS.addTo(today, -(today.dayOfWeek.value - 1).toLong()))
+private fun getThisWeeksDates(date: LocalDate = LocalDate.now()): List<String> {
+    val startOfWeek = date.with(ChronoUnit.DAYS.addTo(date, -(date.dayOfWeek.value - 1).toLong()))
     return List(7) { index ->
         val day = startOfWeek.plusDays(index.toLong())
         day.format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN))

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/component/WeeklyCalendar.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/component/WeeklyCalendar.kt
@@ -1,0 +1,85 @@
+package com.teamhy2.feature.main.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import com.teamhy2.designsystem.ui.theme.Gray400
+import com.teamhy2.designsystem.ui.theme.HY2Theme
+import com.teamhy2.designsystem.ui.theme.White
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoField
+import java.time.temporal.ChronoUnit
+
+private val DAYS_OF_WEEK = listOf("월", "화", "수", "목", "금", "토", "일")
+private const val DATE_FORMAT_PATTERN = "M/d"
+
+@Composable
+fun WeeklyCalendar(
+    studyCounts: List<Int>,
+    dates: List<String>,
+    modifier: Modifier = Modifier,
+) {
+    val daysOfWeek = DAYS_OF_WEEK
+    val currentDate = LocalDate.now()
+
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+    ) {
+        daysOfWeek.forEachIndexed { index, dayOfWeek ->
+            val date = dates.getOrElse(index) { "" }
+            val isFutureDate = isDateInFuture(date, currentDate)
+
+            WeeklyDayComponent(
+                dayOfWeek = dayOfWeek,
+                studyCount = studyCounts.getOrElse(index) { 0 },
+                date = date,
+                textColor = if (isFutureDate) Gray400 else White,
+            )
+        }
+    }
+}
+
+private fun isDateInFuture(
+    dateText: String,
+    currentDate: LocalDate,
+): Boolean {
+    val formatter = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN)
+    val parsedMonthDay = formatter.parse(dateText)
+    val month = parsedMonthDay[ChronoField.MONTH_OF_YEAR]
+    val day = parsedMonthDay[ChronoField.DAY_OF_MONTH]
+    val parsedDate = LocalDate.of(currentDate.year, month, day)
+
+    return parsedDate.isAfter(currentDate)
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewWeeklyCalendar() {
+    val thisWeeksDates = getThisWeeksDates()
+    HY2Theme {
+        WeeklyCalendar(
+            studyCounts = listOf(3, 1, 2, 0, 0, 0, 0),
+            dates = thisWeeksDates,
+            modifier =
+                Modifier
+                    .background(Color.Black),
+        )
+    }
+}
+
+private fun getThisWeeksDates(): List<String> {
+    val today = LocalDate.now()
+    val startOfWeek =
+        today.with(ChronoUnit.DAYS.addTo(today, -(today.dayOfWeek.value - 1).toLong()))
+    return List(7) { index ->
+        val day = startOfWeek.plusDays(index.toLong())
+        day.format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN))
+    }
+}

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/component/WeeklyDayComponent.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/component/WeeklyDayComponent.kt
@@ -1,0 +1,81 @@
+package com.teamhy2.feature.main.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.teamhy2.designsystem.ui.theme.HY2Typography
+import com.teamhy2.designsystem.ui.theme.White
+import com.teamhy2.hongikyeolgong2.main.presentation.R.drawable.ic_star_0
+import com.teamhy2.hongikyeolgong2.main.presentation.R.drawable.ic_star_1
+import com.teamhy2.hongikyeolgong2.main.presentation.R.drawable.ic_star_2
+import com.teamhy2.hongikyeolgong2.main.presentation.R.drawable.ic_star_3
+
+private const val STAR_IMAGE_SIZE = 28
+
+@Composable
+fun WeeklyDayComponent(
+    dayOfWeek: String,
+    studyCount: Int,
+    date: String,
+    textColor: Color = White,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier.padding(horizontal = 6.dp),
+    ) {
+        Text(
+            text = dayOfWeek,
+            style = HY2Typography().caption,
+            color = textColor,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Image(
+            painter = painterResource(id = getStarDrawableId(studyCount)),
+            contentDescription = null,
+            modifier =
+                Modifier
+                    .size(STAR_IMAGE_SIZE.dp),
+        )
+
+        Spacer(modifier = Modifier.height(2.dp))
+
+        Text(
+            text = date,
+            style = HY2Typography().caption,
+            color = textColor,
+        )
+    }
+}
+
+private fun getStarDrawableId(studyCount: Int): Int {
+    return when (studyCount) {
+        1 -> ic_star_1
+        2 -> ic_star_2
+        3 -> ic_star_3
+        else -> ic_star_0
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewWeeklyDayComponent() {
+    WeeklyDayComponent(
+        dayOfWeek = "월",
+        studyCount = 3,
+        date = "9/23",
+    )
+}

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/component/WeeklyDayComponent.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/component/WeeklyDayComponent.kt
@@ -28,7 +28,7 @@ fun WeeklyDayComponent(
     dayOfWeek: String,
     studyCount: Int,
     date: String,
-    textColor: Color = White,
+    textColor: Color,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -77,5 +77,6 @@ private fun PreviewWeeklyDayComponent() {
         dayOfWeek = "월",
         studyCount = 3,
         date = "9/23",
+        textColor = White,
     )
 }

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/component/WeeklyDayComponent.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/component/WeeklyDayComponent.kt
@@ -63,10 +63,10 @@ fun WeeklyDayComponent(
 
 private fun getStarDrawableId(studyCount: Int): Int {
     return when (studyCount) {
+        0 -> ic_star_0
         1 -> ic_star_1
         2 -> ic_star_2
-        3 -> ic_star_3
-        else -> ic_star_0
+        else -> ic_star_3
     }
 }
 

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/model/WeeklyDay.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/model/WeeklyDay.kt
@@ -1,0 +1,6 @@
+package com.teamhy2.feature.main.model
+
+data class WeeklyDay(
+    val studyCount: Int,
+    val date: String,
+)


### PR DESCRIPTION
resolved #91 

## AS-IS
X

## TO-BE
- v2 Home Screen에 존재하는 주간 캘린더를 구현합니다.

## KEY-POINT
- 오늘 기준으로 이후의 텍스트들은 `textColor`가 다르게 나오도록 설정하였습니다.
- 아래 프리뷰는 10/3일의 기준으로 보이는 UI입니다.
- 프리뷰를 확인하는 개발자가 더 이해하기 쉽도록 프리뷰에 `getThisWeeksDates` 함수를 구현하여 실제 현재 날짜가 연동되서 더 직관적으로 로직을 확인할 수 있도록 구현하였습니다.

## SCREENSHOT (Optional)
<img width="593" alt="스크린샷 2024-10-03 오전 12 12 53" src="https://github.com/user-attachments/assets/06739c47-cc30-4a64-8dc8-726ea4e2cb6e">
<img width="157" alt="스크린샷 2024-10-03 오전 12 13 06" src="https://github.com/user-attachments/assets/fd544d28-258a-4dd7-ae5d-6c0bc853cc96">
