### PR TITLE
ResultMapper 변경 및 명언 가져오는 로직 서버연결

### DIFF
--- a/core/remote/src/main/java/com/benenfeldt/remote/api/WiseSayingService.kt
+++ b/core/remote/src/main/java/com/benenfeldt/remote/api/WiseSayingService.kt
@@ -1,0 +1,10 @@
+package com.benenfeldt.remote.api
+
+import com.benenfeldt.remote.dto.BaseResponse
+import com.benenfeldt.remote.dto.WiseSayingResponse
+import retrofit2.http.GET
+
+interface WiseSayingService {
+    @GET("/api/v1/wise-saying")
+    fun getWiseSaying(): Result<BaseResponse<WiseSayingResponse>>
+}

--- a/core/remote/src/main/java/com/benenfeldt/remote/api/WiseSayingService.kt
+++ b/core/remote/src/main/java/com/benenfeldt/remote/api/WiseSayingService.kt
@@ -6,5 +6,5 @@ import retrofit2.http.GET
 
 interface WiseSayingService {
     @GET("/api/v1/wise-saying")
-    fun getWiseSaying(): Result<BaseResponse<WiseSayingResponse>>
+    suspend fun getWiseSaying(): Result<BaseResponse<WiseSayingResponse>>
 }

--- a/core/remote/src/main/java/com/benenfeldt/remote/di/ApiModule.kt
+++ b/core/remote/src/main/java/com/benenfeldt/remote/di/ApiModule.kt
@@ -2,6 +2,7 @@ package com.benenfeldt.remote.di
 
 import com.benenfeldt.remote.api.UserPublicService
 import com.benenfeldt.remote.api.UserService
+import com.benenfeldt.remote.api.WiseSayingService
 import com.benenfeldt.remote.token.NeedAuthRetrofit
 import com.benenfeldt.remote.token.PublicRetrofit
 import dagger.Module
@@ -28,5 +29,13 @@ object ApiModule {
         @PublicRetrofit retrofit: Retrofit,
     ): UserPublicService {
         return retrofit.create(UserPublicService::class.java)
+    }
+
+    @Singleton
+    @Provides
+    fun provideWiseSayingService(
+        @NeedAuthRetrofit retrofit: Retrofit,
+    ): WiseSayingService {
+        return retrofit.create(WiseSayingService::class.java)
     }
 }

--- a/core/remote/src/main/java/com/benenfeldt/remote/dto/BaseResponse.kt
+++ b/core/remote/src/main/java/com/benenfeldt/remote/dto/BaseResponse.kt
@@ -8,4 +8,6 @@ data class BaseResponse<T>(
     val `data`: T,
     val status: String,
     val message: String,
-)
+) {
+    fun isSuccess() = code in 200..299
+}

--- a/core/remote/src/main/java/com/benenfeldt/remote/dto/WiseSayingResponse.kt
+++ b/core/remote/src/main/java/com/benenfeldt/remote/dto/WiseSayingResponse.kt
@@ -1,0 +1,10 @@
+package com.benenfeldt.remote.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WiseSayingResponse(
+    val id: Int,
+    val author: String,
+    val quote: String,
+)

--- a/core/remote/src/main/java/com/benenfeldt/remote/mapper/ResultMapper.kt
+++ b/core/remote/src/main/java/com/benenfeldt/remote/mapper/ResultMapper.kt
@@ -1,10 +1,28 @@
 package com.benenfeldt.remote.mapper
 
+import com.benenfeldt.remote.dto.BaseResponse
+
 private const val UNEXPECTED_ERROR_IN_MAPPER = "Unexpected Error in Mapper"
 
-fun <T, R> Result<T>.toResult(mapper: (T) -> R): Result<R> {
+fun <T, R> Result<BaseResponse<T>>.toResult(mapper: (BaseResponse<T>) -> R): Result<R> {
     this.onSuccess {
-        return Result.success(mapper(it))
+        if (it.isSuccess()) {
+            return Result.success(mapper(it))
+        }
+        return Result.failure(IllegalStateException(it.message))
+    }.onFailure {
+        return Result.failure(it)
+    }
+
+    return Result.failure(Exception(UNEXPECTED_ERROR_IN_MAPPER))
+}
+
+fun <T> Result<BaseResponse<T>>.toResult(): Result<Unit> {
+    this.onSuccess {
+        if (it.isSuccess()) {
+            return Result.success(Unit)
+        }
+        return Result.failure(IllegalStateException(it.message))
     }.onFailure {
         return Result.failure(it)
     }

--- a/core/remote/src/main/java/com/benenfeldt/remote/mapper/UserMapper.kt
+++ b/core/remote/src/main/java/com/benenfeldt/remote/mapper/UserMapper.kt
@@ -1,6 +1,0 @@
-package com.benenfeldt.remote.mapper
-
-import com.benenfeldt.remote.dto.UserSignInResponse
-
-fun UserSignInResponse.toDomain() {
-}

--- a/main-data/build.gradle.kts
+++ b/main-data/build.gradle.kts
@@ -8,6 +8,7 @@ android {
 
 dependencies {
     implementation(projects.mainDomain)
+    implementation(projects.core.remote)
 
     implementation(libs.firebase.firestore.ktx)
 }

--- a/main-data/src/main/java/com/teamhy2/main/data/mapper/WiseSayingMapper.kt
+++ b/main-data/src/main/java/com/teamhy2/main/data/mapper/WiseSayingMapper.kt
@@ -1,0 +1,11 @@
+package com.teamhy2.main.data.mapper
+
+import com.benenfeldt.remote.dto.WiseSayingResponse
+import com.teamhy2.main.domain.model.WiseSaying
+
+fun WiseSayingResponse.toDomain(): WiseSaying {
+    return WiseSaying(
+        quote = quote,
+        author = author,
+    )
+}

--- a/main-data/src/main/java/com/teamhy2/main/data/repository/DefaultWiseSayingRepository.kt
+++ b/main-data/src/main/java/com/teamhy2/main/data/repository/DefaultWiseSayingRepository.kt
@@ -1,34 +1,20 @@
 package com.teamhy2.main.data.repository
 
-import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.QuerySnapshot
+import com.benenfeldt.remote.api.WiseSayingService
+import com.benenfeldt.remote.mapper.toResult
+import com.teamhy2.main.data.mapper.toDomain
 import com.teamhy2.main.domain.model.WiseSaying
 import com.teamhy2.main.domain.repository.WiseSayingRepository
-import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
-import kotlin.random.Random
 
 class DefaultWiseSayingRepository
     @Inject
-    constructor() : WiseSayingRepository {
-        private val firestore = FirebaseFirestore.getInstance()
-
-        override suspend fun fetchWiseSaying(): WiseSaying {
-            val result: QuerySnapshot = firestore.collection(WISE_SAYINGS_COLLECTION).get().await()
-            if (result.isEmpty) return WiseSaying("", "")
-
-            val randomIndex = Random.nextInt(result.size())
-            val document = result.documents[randomIndex]
-
-            val quote = document.getString(WISE_SAYINGS_QUOTE_FIELD) ?: ""
-            val author = document.getString(WISE_SAYINGS_AUTHOR_FIELD) ?: ""
-
-            return WiseSaying(quote, author)
-        }
-
-        companion object {
-            private const val WISE_SAYINGS_COLLECTION = "WiseSaying"
-            private const val WISE_SAYINGS_QUOTE_FIELD = "quote"
-            private const val WISE_SAYINGS_AUTHOR_FIELD = "author"
+    constructor(
+        private val wiseSayingService: WiseSayingService,
+    ) : WiseSayingRepository {
+        override suspend fun fetchWiseSaying(): Result<WiseSaying> {
+            return wiseSayingService.getWiseSaying().toResult { baseResponse ->
+                baseResponse.data.toDomain()
+            }
         }
     }

--- a/main-domain/src/main/java/com/teamhy2/main/domain/model/WiseSaying.kt
+++ b/main-domain/src/main/java/com/teamhy2/main/domain/model/WiseSaying.kt
@@ -3,4 +3,12 @@ package com.teamhy2.main.domain.model
 data class WiseSaying(
     val quote: String,
     val author: String,
-)
+) {
+    companion object {
+        val DEFAULT =
+            WiseSaying(
+                quote = "우선 무엇이 되고자 하는지 자신에게 말하라.\n그리고 나서 할 일을 하라.",
+                author = "에픽테토스",
+            )
+    }
+}

--- a/main-domain/src/main/java/com/teamhy2/main/domain/repository/WiseSayingRepository.kt
+++ b/main-domain/src/main/java/com/teamhy2/main/domain/repository/WiseSayingRepository.kt
@@ -3,5 +3,5 @@ package com.teamhy2.main.domain.repository
 import com.teamhy2.main.domain.model.WiseSaying
 
 interface WiseSayingRepository {
-    suspend fun fetchWiseSaying(): WiseSaying
+    suspend fun fetchWiseSaying(): Result<WiseSaying>
 }

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/MainViewModel.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/MainViewModel.kt
@@ -38,10 +38,10 @@ class MainViewModel
 
         private fun getWiseSaying() {
             viewModelScope.launch {
-                _mainUiState.value =
-                    _mainUiState.value.copy(
-                        wiseSaying = wiseSayingRepository.fetchWiseSaying(),
-                    )
+                wiseSayingRepository.fetchWiseSaying()
+                    .onSuccess { wiseSaying ->
+                        _mainUiState.value = _mainUiState.value.copy(wiseSaying = wiseSaying)
+                    }
             }
         }
 

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/model/MainUiState.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/model/MainUiState.kt
@@ -9,7 +9,7 @@ data class MainUiState(
     val isTimePickerVisible: Boolean = false,
     val isStudyRoomExtendDialog: Boolean = false,
     val isStudyRoomEndDialog: Boolean = false,
-    val wiseSaying: WiseSaying = WiseSaying("", ""),
+    val wiseSaying: WiseSaying = WiseSaying.DEFAULT,
     val selectedTime: LocalDateTime = LocalDateTime.now(),
     val calendar: Calendar = Calendar(studyDays = emptyList()),
     val startTime: String = "",

--- a/onboarding-data/src/main/java/com/teamhy2/onboarding/data/repository/RemoteUserRepository.kt
+++ b/onboarding-data/src/main/java/com/teamhy2/onboarding/data/repository/RemoteUserRepository.kt
@@ -8,6 +8,7 @@ import com.benenfeldt.remote.mapper.toResult
 import com.benenfeldt.remote.token.JwtManager
 import com.teamhy2.core.auth.SocialSignIn
 import com.teamhy2.onboarding.domain.repository.AlreadyExist
+import com.teamhy2.onboarding.domain.repository.Duplication
 import com.teamhy2.onboarding.domain.repository.UserRepository
 import javax.inject.Inject
 
@@ -19,8 +20,10 @@ class RemoteUserRepository
         private val jwtManager: JwtManager,
         private val socialSignIn: SocialSignIn,
     ) : UserRepository {
-        override suspend fun checkNicknameDuplication(nickname: String): Result<Boolean> {
-            return userPublicService.checkNicknameDuplication(nickname).toResult { it.data.duplicate }
+        override suspend fun checkNicknameDuplication(nickname: String): Result<Duplication> {
+            return userPublicService.checkNicknameDuplication(nickname).toResult { baseResponse ->
+                baseResponse.data.duplicate
+            }
         }
 
         override suspend fun signUp(
@@ -32,7 +35,7 @@ class RemoteUserRepository
                     nickname = nickname,
                     department = department,
                 ),
-            ).toResult { it.code in 200 until 300 }
+            ).toResult()
         }
 
         override suspend fun signIn(idToken: String): Result<AlreadyExist> {
@@ -41,11 +44,13 @@ class RemoteUserRepository
                     idToken = idToken,
                 ),
             )
-                .onSuccess {
-                    jwtManager.saveAccessJwt(it.data.accessToken)
+                .onSuccess { baseResponse ->
+                    if (baseResponse.isSuccess()) {
+                        jwtManager.saveAccessJwt(baseResponse.data.accessToken)
+                    }
                 }
-                .toResult {
-                    it.data.alreadyExist
+                .toResult { baseResponse ->
+                    baseResponse.data.alreadyExist
                 }
         }
 
@@ -56,7 +61,11 @@ class RemoteUserRepository
 
         override suspend fun withdraw(): Result<Unit> {
             return userService.withdraw()
-                .onSuccess { jwtManager.clearAllTokens() }
-                .toResult { }
+                .onSuccess { baseResponse ->
+                    if (baseResponse.isSuccess()) {
+                        jwtManager.clearAllTokens()
+                    }
+                }
+                .toResult()
         }
     }

--- a/onboarding-domain/src/main/java/com/teamhy2/onboarding/domain/repository/UserRepository.kt
+++ b/onboarding-domain/src/main/java/com/teamhy2/onboarding/domain/repository/UserRepository.kt
@@ -1,9 +1,10 @@
 package com.teamhy2.onboarding.domain.repository
 
 typealias AlreadyExist = Boolean
+typealias Duplication = Boolean
 
 interface UserRepository {
-    suspend fun checkNicknameDuplication(nickname: String): Result<Boolean>
+    suspend fun checkNicknameDuplication(nickname: String): Result<Duplication>
 
     suspend fun signUp(
         nickname: String,


### PR DESCRIPTION
resolved #117 

## AS-IS
- 기존 `ResultMapper`
    - BaseResponse의 응답 코드가 400 혹은 500대여도 Success로 취급
    - 제네릭 타입 `<T>`만 허용, `BaseResponse` 특화 x
- 파이어 스토어에서 가져오던 명언을

## TO-BE
- 변경 후 `ResultMapper`
    - `BaseResponse`의 응답 코드가 200대일 때만 Success로 취급
    - 제네릭 타입 `<BaseResponse<T>>`
- 서버에서 가져오는 것으로 변경하였습니다.

## KEY-POINT
- `ResultMapper` 변경사항을 잘 인지하시면 좋을 것 같고 질문은 언제나 환영입니다.
- 명언을 가져올 때 실패하는 케이스엔 따로 오류처리 보단 디폴트 명언을 넣도록 구현해보았습니다.
    - 사유: 명언이 없어도 유저의 사용에 있어서, 치명적인 오류를 내지 않습니다.

## SCREENSHOT (Optional)
![Oct-27-2024 21-19-38](https://github.com/user-attachments/assets/6c4aa335-380e-4de5-a7d2-3daae2b32cdf)
