### PR TITLE
[Fix] 자정 기준으로 발생할 수 있는 시간 버그들을 수정

### DIFF
--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2TimePicker.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2TimePicker.kt
@@ -53,6 +53,7 @@ import com.teamhy2.designsystem.ui.theme.White
 import com.teamhy2.designsystem.util.pixelsToDp
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import java.time.Duration
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.util.Locale
@@ -62,7 +63,7 @@ private const val DIALOG_CORNER_RADIUS = 8
 private const val DIALOG_BACKGROUND_DIM_AMOUNT = 0.75f
 private const val TIME_PICKER_NUMBER_FORMAT = "%02d"
 private const val PICKER_DEFAULT_VISIBLE_ITEMS_COUNT = 3
-private const val MAXIMUM_PREVIOUS_TIME = 3
+private const val MAXIMUM_PREVIOUS_TIME = 3L
 
 @Composable
 fun HY2TimePicker(
@@ -99,7 +100,7 @@ fun HY2TimePicker(
                             String.format(
                                 Locale.KOREA,
                                 TIME_PICKER_NUMBER_FORMAT,
-                                localDateTime.minusHours((MAXIMUM_PREVIOUS_TIME - index).toLong()).hour,
+                                localDateTime.minusHours(MAXIMUM_PREVIOUS_TIME - index).hour,
                             )
                         } + listOf("")
                 }
@@ -107,7 +108,14 @@ fun HY2TimePicker(
 
             val minutes: List<String> =
                 remember {
-                    listOf("") + (0..59).map { String.format(Locale.KOREA, TIME_PICKER_NUMBER_FORMAT, it) } + listOf("")
+                    listOf("") +
+                        (0..59).map {
+                            String.format(
+                                Locale.KOREA,
+                                TIME_PICKER_NUMBER_FORMAT,
+                                it,
+                            )
+                        } + listOf("")
                 }
             val minuteState: PickerState = rememberPickerState()
 
@@ -172,12 +180,22 @@ fun HY2TimePicker(
                 HY2DialogButton(
                     text = stringResource(R.string.time_picker_confirm),
                     onClick = {
-                        onSelected(
+                        val selectedDateTime: LocalDateTime =
                             LocalDateTime
                                 .now()
                                 .withHour(hourState.selectedItem.toInt())
-                                .withMinute(minuteState.selectedItem.toInt()),
-                        )
+                                .withMinute(minuteState.selectedItem.toInt())
+
+                        val finalDateTime: LocalDateTime =
+                            if (Duration.between(selectedDateTime, LocalDateTime.now())
+                                    .abs() > Duration.ofHours(MAXIMUM_PREVIOUS_TIME)
+                            ) {
+                                selectedDateTime.minusDays(1)
+                            } else {
+                                selectedDateTime
+                            }
+
+                        onSelected(finalDateTime)
                     },
                     buttonColor = Blue100,
                     textColor = White,

--- a/main-data/src/main/java/com/teamhy2/main/data/repository/RemoteStudyDayRepository.kt
+++ b/main-data/src/main/java/com/teamhy2/main/data/repository/RemoteStudyDayRepository.kt
@@ -23,13 +23,13 @@ class RemoteStudyDayRepository
         }
 
         override suspend fun saveStudyDay(
-            startTime: LocalDateTime,
-            endTime: LocalDateTime,
+            startDateTime: LocalDateTime,
+            endDateTime: LocalDateTime,
         ): Result<StudyDayRecord> {
             val studyDayRequest =
                 StudyDayRequest(
-                    startTime = startTime.format(studyDayFormatter),
-                    endTime = endTime.format(studyDayFormatter),
+                    startTime = startDateTime.format(studyDayFormatter),
+                    endTime = endDateTime.format(studyDayFormatter),
                 )
 
             return studyService.postStudyDay(studyDayRequest).toResult { baseResponse ->

--- a/main-domain/src/main/java/com/teamhy2/main/domain/repository/StudyDayRepository.kt
+++ b/main-domain/src/main/java/com/teamhy2/main/domain/repository/StudyDayRepository.kt
@@ -8,7 +8,7 @@ interface StudyDayRepository {
     suspend fun fetchWeeklyStudyDay(): Result<List<WeeklyStudyDay>>
 
     suspend fun saveStudyDay(
-        startTime: LocalDateTime,
-        endTime: LocalDateTime,
+        startDateTime: LocalDateTime,
+        endDateTime: LocalDateTime,
     ): Result<StudyDayRecord>
 }

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/HomeScreen.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/HomeScreen.kt
@@ -99,18 +99,15 @@ fun HomeRoute(
             if (uiState.isTimePickerVisible) {
                 HY2TimePicker(
                     title = stringResource(R.string.main_study_room_use_start_time),
-                    onSelected = { selectedTime ->
-                        val updatedSelectedTime =
-                            selectedTime.plusSeconds(LocalDateTime.now().second.toLong())
-
+                    onSelected = { selectedDateTime ->
                         homeViewModel.run {
-                            updateSelectedTime(updatedSelectedTime)
+                            updateSelectedTime(selectedDateTime)
                             updateTimePickerVisibility(false)
                             updateTimerRunning(true)
                         }
-                        startTimer(updatedSelectedTime, homeViewModel, timerViewModel)
+                        startTimer(selectedDateTime, homeViewModel, timerViewModel)
                         homeViewModel.startTimerService(
-                            startTime = updatedSelectedTime,
+                            startDateTime = selectedDateTime,
                             duration = timerViewModel.durationHour.value,
                         )
                         tracker.trackEvent("StudyStartButton")
@@ -146,7 +143,7 @@ fun HomeRoute(
                         )
                         homeViewModel.stopTimerService()
                         homeViewModel.startTimerService(
-                            startTime = LocalDateTime.now(),
+                            startDateTime = LocalDateTime.now(),
                             duration = timerViewModel.durationHour.value,
                         )
                         tracker.trackEvent("StudyExtendButton")
@@ -221,12 +218,12 @@ fun SetNavigationBarColor(color: Color) {
 }
 
 private fun startTimer(
-    startTime: LocalDateTime,
+    startDateTime: LocalDateTime,
     homeViewModel: HomeViewModel,
     timerViewModel: TimerViewModel,
 ) {
     timerViewModel.setTimer(
-        startTime = startTime,
+        startDateTime = startDateTime,
         events =
             mapOf(
                 Timer.TIME_OVER to {

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/HomeScreen.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/HomeScreen.kt
@@ -40,7 +40,7 @@ import com.teamhy2.feature.home.model.HomeUiState
 import com.teamhy2.hongikyeolgong2.main.presentation.R
 import com.teamhy2.hongikyeolgong2.timer.model.Timer
 import com.teamhy2.hongikyeolgong2.timer.presentation.TimerViewModel
-import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerUiModel
+import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerUiState
 import com.teamhy2.main.domain.model.WeeklyStudyDay
 import com.teamhy2.main.domain.model.WiseSaying
 import kotlinx.coroutines.flow.collectLatest
@@ -180,7 +180,7 @@ fun HomeRoute(
                 wiseSaying = uiState.wiseSaying,
                 durationAsSecond = duration.seconds,
                 isTimerRunning = uiState.isTimerRunning,
-                timerUiModel = uiState.timerUiModel,
+                timerUiState = uiState.timerUiState,
                 modifier = modifier,
                 onSeatingChartClick = {
                     val intent = Intent(Intent.ACTION_VIEW, Uri.parse(seatingChartUrl))
@@ -240,7 +240,7 @@ fun HomeScreen(
     wiseSaying: WiseSaying,
     durationAsSecond: Long,
     isTimerRunning: Boolean,
-    timerUiModel: TimerUiModel,
+    timerUiState: TimerUiState,
     onSeatingChartClick: () -> Unit,
     onStudyRoomStartClick: () -> Unit,
     onStudyRoomExtendClick: () -> Unit,
@@ -263,7 +263,7 @@ fun HomeScreen(
             durationAsSecond = durationAsSecond,
             wiseSaying = wiseSaying,
             isTimerRunning = isTimerRunning,
-            timerUiModel = timerUiModel,
+            timerUiState = timerUiState,
             onSeatingChartClick = onSeatingChartClick,
             onStudyRoomStartClick = onStudyRoomStartClick,
             onStudyRoomExtendClick = onStudyRoomExtendClick,
@@ -292,7 +292,7 @@ private fun HomeBody(
     durationAsSecond: Long,
     wiseSaying: WiseSaying,
     isTimerRunning: Boolean,
-    timerUiModel: TimerUiModel,
+    timerUiState: TimerUiState,
     onSeatingChartClick: () -> Unit,
     onStudyRoomStartClick: () -> Unit,
     onStudyRoomExtendClick: () -> Unit,
@@ -309,11 +309,11 @@ private fun HomeBody(
             true -> {
                 RunningTimerComponent(
                     durationAsSecond = durationAsSecond,
-                    startTime = timerUiModel.startTime,
-                    endTime = timerUiModel.endTime,
-                    startTimeMeridiem = timerUiModel.startTimeMeridiem,
-                    endTimeMeridiem = timerUiModel.endTimeMeridiem,
-                    leftTime = timerUiModel.leftTime,
+                    startTime = timerUiState.startTime,
+                    endTime = timerUiState.endTime,
+                    startTimeMeridiem = timerUiState.startTimeMeridiem,
+                    endTimeMeridiem = timerUiState.endTimeMeridiem,
+                    leftTime = timerUiState.leftTime,
                     onStudyRoomExtendClick = onStudyRoomExtendClick,
                     onStudyRoomEndClick = onStudyRoomEndClick,
                 )
@@ -345,7 +345,7 @@ private fun HomeScreenPreview() {
             onStudyRoomExtendClick = { },
             onStudyRoomEndClick = { },
             isTimerRunning = false,
-            timerUiModel = TimerUiModel(),
+            timerUiState = TimerUiState(),
         )
     }
 }

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/HomeViewModel.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/HomeViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.teamhy2.feature.home.model.HomeUiState
 import com.teamhy2.hongikyeolgong2.timer.model.TimerService
-import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerUiModel
+import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerUiState
 import com.teamhy2.main.domain.model.WeeklyStudyDay
 import com.teamhy2.main.domain.model.WiseSaying
 import com.teamhy2.main.domain.repository.StudyDayRepository
@@ -81,7 +81,7 @@ class HomeViewModel
             if (currentState is HomeUiState.Success) {
                 viewModelScope.launch {
                     studyDayRepository.saveStudyDay(
-                        currentState.timerUiModel.startDateTime,
+                        currentState.timerUiState.startDateTime,
                         LocalDateTime.now(),
                     ).onSuccess {
                         if (!isExtend) loadHomeData()
@@ -92,12 +92,12 @@ class HomeViewModel
             }
         }
 
-        fun updateTimerStateFromTimerViewModel(timerState: TimerUiModel) {
+        fun updateTimerStateFromTimerViewModel(timerState: TimerUiState) {
             _homeUiState.update { currentState ->
                 when (currentState) {
                     is HomeUiState.Success -> {
                         currentState.copy(
-                            timerUiModel = timerState,
+                            timerUiState = timerState,
                         )
                     }
 

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/HomeViewModel.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/HomeViewModel.kt
@@ -81,8 +81,8 @@ class HomeViewModel
             if (currentState is HomeUiState.Success) {
                 viewModelScope.launch {
                     studyDayRepository.saveStudyDay(
-                        currentState.timerUiState.startDateTime,
-                        LocalDateTime.now(),
+                        startDateTime = currentState.timerUiState.startDateTime,
+                        endDateTime = LocalDateTime.now(),
                     ).onSuccess {
                         if (!isExtend) loadHomeData()
                     }.onFailure { throwable ->

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/HomeViewModel.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/HomeViewModel.kt
@@ -26,128 +26,128 @@ import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel
-@Inject
-constructor(
-    private val wiseSayingRepository: WiseSayingRepository,
-    private val studyDayRepository: StudyDayRepository,
-    private val timerService: TimerService,
-) : ViewModel() {
-    private val _homeUiState = MutableStateFlow<HomeUiState>(HomeUiState.Loading)
-    val homeUiState: StateFlow<HomeUiState> = _homeUiState.asStateFlow()
+    @Inject
+    constructor(
+        private val wiseSayingRepository: WiseSayingRepository,
+        private val studyDayRepository: StudyDayRepository,
+        private val timerService: TimerService,
+    ) : ViewModel() {
+        private val _homeUiState = MutableStateFlow<HomeUiState>(HomeUiState.Loading)
+        val homeUiState: StateFlow<HomeUiState> = _homeUiState.asStateFlow()
 
-    private val _errorFlow = MutableSharedFlow<Throwable>()
-    val errorFlow: SharedFlow<Throwable> = _errorFlow.asSharedFlow()
+        private val _errorFlow = MutableSharedFlow<Throwable>()
+        val errorFlow: SharedFlow<Throwable> = _errorFlow.asSharedFlow()
 
-    init {
-        loadHomeData()
-    }
-
-    private fun loadHomeData() {
-        viewModelScope.launch {
-            runCatching {
-                listOf(
-                    async { wiseSayingRepository.fetchWiseSaying().getOrThrow() },
-                    async { studyDayRepository.fetchWeeklyStudyDay().getOrThrow() },
-                ).awaitAll()
-            }.onSuccess { results ->
-                val (wiseSaying, weeklyStudyDays) = results
-
-                _homeUiState.update {
-                    HomeUiState.Success(
-                        wiseSaying = wiseSaying as WiseSaying,
-                        weeklyStudyDays = weeklyStudyDays as List<WeeklyStudyDay>,
-                    )
-                }
-            }.onFailure { exception ->
-                _errorFlow.emit(exception)
-                _homeUiState.value = HomeUiState.Error(exception.message)
-            }
+        init {
+            loadHomeData()
         }
-    }
 
-    fun startTimerService(
-        startDateTime: LocalDateTime,
-        duration: Duration,
-    ) {
-        timerService.startService(startDateTime, duration)
-    }
-
-    fun stopTimerService() {
-        timerService.stopService()
-    }
-
-    fun saveStudyDay(isExtend: Boolean) {
-        val currentState = _homeUiState.value
-        if (currentState is HomeUiState.Success) {
+        private fun loadHomeData() {
             viewModelScope.launch {
-                studyDayRepository.saveStudyDay(
-                    currentState.timerUiModel.startDateTime,
-                    LocalDateTime.now(),
-                ).onSuccess {
-                    if (!isExtend) loadHomeData()
-                }.onFailure { throwable ->
-                    _errorFlow.emit(throwable)
+                runCatching {
+                    listOf(
+                        async { wiseSayingRepository.fetchWiseSaying().getOrThrow() },
+                        async { studyDayRepository.fetchWeeklyStudyDay().getOrThrow() },
+                    ).awaitAll()
+                }.onSuccess { results ->
+                    val (wiseSaying, weeklyStudyDays) = results
+
+                    _homeUiState.update {
+                        HomeUiState.Success(
+                            wiseSaying = wiseSaying as WiseSaying,
+                            weeklyStudyDays = weeklyStudyDays as List<WeeklyStudyDay>,
+                        )
+                    }
+                }.onFailure { exception ->
+                    _errorFlow.emit(exception)
+                    _homeUiState.value = HomeUiState.Error(exception.message)
+                }
+            }
+        }
+
+        fun startTimerService(
+            startDateTime: LocalDateTime,
+            duration: Duration,
+        ) {
+            timerService.startService(startDateTime, duration)
+        }
+
+        fun stopTimerService() {
+            timerService.stopService()
+        }
+
+        fun saveStudyDay(isExtend: Boolean) {
+            val currentState = _homeUiState.value
+            if (currentState is HomeUiState.Success) {
+                viewModelScope.launch {
+                    studyDayRepository.saveStudyDay(
+                        currentState.timerUiModel.startDateTime,
+                        LocalDateTime.now(),
+                    ).onSuccess {
+                        if (!isExtend) loadHomeData()
+                    }.onFailure { throwable ->
+                        _errorFlow.emit(throwable)
+                    }
+                }
+            }
+        }
+
+        fun updateTimerStateFromTimerViewModel(timerState: TimerUiModel) {
+            _homeUiState.update { currentState ->
+                when (currentState) {
+                    is HomeUiState.Success -> {
+                        currentState.copy(
+                            timerUiModel = timerState,
+                        )
+                    }
+
+                    else -> currentState
+                }
+            }
+        }
+
+        fun updateTimePickerVisibility(isVisible: Boolean) {
+            _homeUiState.update { currentState ->
+                when (currentState) {
+                    is HomeUiState.Success -> currentState.copy(isTimePickerVisible = isVisible)
+                    else -> currentState
+                }
+            }
+        }
+
+        fun updateTimerRunning(isTimerRunning: Boolean) {
+            _homeUiState.update { currentState ->
+                when (currentState) {
+                    is HomeUiState.Success -> currentState.copy(isTimerRunning = isTimerRunning)
+                    else -> currentState
+                }
+            }
+        }
+
+        fun updateSelectedTime(selectedTime: LocalDateTime) {
+            _homeUiState.update { currentState ->
+                when (currentState) {
+                    is HomeUiState.Success -> currentState.copy(selectedTime = selectedTime)
+                    else -> currentState
+                }
+            }
+        }
+
+        fun updateStudyRoomExtendDialogVisibility(isVisible: Boolean) {
+            _homeUiState.update { currentState ->
+                when (currentState) {
+                    is HomeUiState.Success -> currentState.copy(isStudyRoomExtendDialog = isVisible)
+                    else -> currentState
+                }
+            }
+        }
+
+        fun updateStudyRoomEndDialogVisibility(isVisible: Boolean) {
+            _homeUiState.update { currentState ->
+                when (currentState) {
+                    is HomeUiState.Success -> currentState.copy(isStudyRoomEndDialog = isVisible)
+                    else -> currentState
                 }
             }
         }
     }
-
-    fun updateTimerStateFromTimerViewModel(timerState: TimerUiModel) {
-        _homeUiState.update { currentState ->
-            when (currentState) {
-                is HomeUiState.Success -> {
-                    currentState.copy(
-                        timerUiModel = timerState,
-                    )
-                }
-
-                else -> currentState
-            }
-        }
-    }
-
-    fun updateTimePickerVisibility(isVisible: Boolean) {
-        _homeUiState.update { currentState ->
-            when (currentState) {
-                is HomeUiState.Success -> currentState.copy(isTimePickerVisible = isVisible)
-                else -> currentState
-            }
-        }
-    }
-
-    fun updateTimerRunning(isTimerRunning: Boolean) {
-        _homeUiState.update { currentState ->
-            when (currentState) {
-                is HomeUiState.Success -> currentState.copy(isTimerRunning = isTimerRunning)
-                else -> currentState
-            }
-        }
-    }
-
-    fun updateSelectedTime(selectedTime: LocalDateTime) {
-        _homeUiState.update { currentState ->
-            when (currentState) {
-                is HomeUiState.Success -> currentState.copy(selectedTime = selectedTime)
-                else -> currentState
-            }
-        }
-    }
-
-    fun updateStudyRoomExtendDialogVisibility(isVisible: Boolean) {
-        _homeUiState.update { currentState ->
-            when (currentState) {
-                is HomeUiState.Success -> currentState.copy(isStudyRoomExtendDialog = isVisible)
-                else -> currentState
-            }
-        }
-    }
-
-    fun updateStudyRoomEndDialogVisibility(isVisible: Boolean) {
-        _homeUiState.update { currentState ->
-            when (currentState) {
-                is HomeUiState.Success -> currentState.copy(isStudyRoomEndDialog = isVisible)
-                else -> currentState
-            }
-        }
-    }
-}

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/HomeViewModel.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/HomeViewModel.kt
@@ -22,156 +22,132 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.Duration
 import java.time.LocalDateTime
-import java.time.LocalTime
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel
-    @Inject
-    constructor(
-        private val wiseSayingRepository: WiseSayingRepository,
-        private val studyDayRepository: StudyDayRepository,
-        private val timerService: TimerService,
-    ) : ViewModel() {
-        private val _homeUiState = MutableStateFlow<HomeUiState>(HomeUiState.Loading)
-        val homeUiState: StateFlow<HomeUiState> = _homeUiState.asStateFlow()
+@Inject
+constructor(
+    private val wiseSayingRepository: WiseSayingRepository,
+    private val studyDayRepository: StudyDayRepository,
+    private val timerService: TimerService,
+) : ViewModel() {
+    private val _homeUiState = MutableStateFlow<HomeUiState>(HomeUiState.Loading)
+    val homeUiState: StateFlow<HomeUiState> = _homeUiState.asStateFlow()
 
-        private val _errorFlow = MutableSharedFlow<Throwable>()
-        val errorFlow: SharedFlow<Throwable> = _errorFlow.asSharedFlow()
+    private val _errorFlow = MutableSharedFlow<Throwable>()
+    val errorFlow: SharedFlow<Throwable> = _errorFlow.asSharedFlow()
 
-        init {
-            loadHomeData()
-        }
+    init {
+        loadHomeData()
+    }
 
-        private fun loadHomeData() {
-            viewModelScope.launch {
-                runCatching {
-                    listOf(
-                        async { wiseSayingRepository.fetchWiseSaying().getOrThrow() },
-                        async { studyDayRepository.fetchWeeklyStudyDay().getOrThrow() },
-                    ).awaitAll()
-                }.onSuccess { results ->
-                    val (wiseSaying, weeklyStudyDays) = results
+    private fun loadHomeData() {
+        viewModelScope.launch {
+            runCatching {
+                listOf(
+                    async { wiseSayingRepository.fetchWiseSaying().getOrThrow() },
+                    async { studyDayRepository.fetchWeeklyStudyDay().getOrThrow() },
+                ).awaitAll()
+            }.onSuccess { results ->
+                val (wiseSaying, weeklyStudyDays) = results
 
-                    _homeUiState.update {
-                        HomeUiState.Success(
-                            wiseSaying = wiseSaying as WiseSaying,
-                            weeklyStudyDays = weeklyStudyDays as List<WeeklyStudyDay>,
-                        )
-                    }
-                }.onFailure { exception ->
-                    _errorFlow.emit(exception)
-                    _homeUiState.value = HomeUiState.Error(exception.message)
-                }
-            }
-        }
-
-        fun startTimerService(
-            startTime: LocalDateTime,
-            duration: Duration,
-        ) {
-            timerService.startService(startTime, duration)
-        }
-
-        fun stopTimerService() {
-            timerService.stopService()
-        }
-
-        fun saveStudyDay(isExtend: Boolean) {
-            val currentState = _homeUiState.value
-            if (currentState is HomeUiState.Success) {
-                val startDateTime =
-                    parseStartTimeToLocalDateTime(
-                        currentState.timerUiModel.startTime,
-                        currentState.timerUiModel.startTimeMeridiem,
+                _homeUiState.update {
+                    HomeUiState.Success(
+                        wiseSaying = wiseSaying as WiseSaying,
+                        weeklyStudyDays = weeklyStudyDays as List<WeeklyStudyDay>,
                     )
-                val endDateTime = LocalDateTime.now()
-
-                viewModelScope.launch {
-                    studyDayRepository.saveStudyDay(startDateTime, endDateTime)
-                        .onSuccess {
-                            if (!isExtend) loadHomeData()
-                        }.onFailure { throwable ->
-                            _errorFlow.emit(throwable)
-                        }
                 }
+            }.onFailure { exception ->
+                _errorFlow.emit(exception)
+                _homeUiState.value = HomeUiState.Error(exception.message)
             }
         }
+    }
 
-        private fun parseStartTimeToLocalDateTime(
-            startTime: String,
-            startTimeMeridiem: String,
-        ): LocalDateTime {
-            val timeParts = startTime.split(":").map { it.toInt() }
-            var hour = timeParts[0]
-            val minute = timeParts[1]
+    fun startTimerService(
+        startDateTime: LocalDateTime,
+        duration: Duration,
+    ) {
+        timerService.startService(startDateTime, duration)
+    }
 
-            if (startTimeMeridiem == "PM" && hour < 12) {
-                hour += 12
-            } else if (startTimeMeridiem == "AM" && hour == 12) {
-                hour = 0
-            }
+    fun stopTimerService() {
+        timerService.stopService()
+    }
 
-            val startTimeLocalTime = LocalTime.of(hour, minute)
-            return LocalDateTime.of(LocalDateTime.now().toLocalDate(), startTimeLocalTime)
-        }
-
-        fun updateTimerStateFromTimerViewModel(timerState: TimerUiModel) {
-            _homeUiState.update { currentState ->
-                when (currentState) {
-                    is HomeUiState.Success -> {
-                        currentState.copy(
-                            timerUiModel = timerState,
-                        )
-                    }
-
-                    else -> currentState
-                }
-            }
-        }
-
-        fun updateTimePickerVisibility(isVisible: Boolean) {
-            _homeUiState.update { currentState ->
-                when (currentState) {
-                    is HomeUiState.Success -> currentState.copy(isTimePickerVisible = isVisible)
-                    else -> currentState
-                }
-            }
-        }
-
-        fun updateTimerRunning(isTimerRunning: Boolean) {
-            _homeUiState.update { currentState ->
-                when (currentState) {
-                    is HomeUiState.Success -> currentState.copy(isTimerRunning = isTimerRunning)
-                    else -> currentState
-                }
-            }
-        }
-
-        fun updateSelectedTime(selectedTime: LocalDateTime) {
-            _homeUiState.update { currentState ->
-                when (currentState) {
-                    is HomeUiState.Success -> currentState.copy(selectedTime = selectedTime)
-                    else -> currentState
-                }
-            }
-        }
-
-        fun updateStudyRoomExtendDialogVisibility(isVisible: Boolean) {
-            _homeUiState.update { currentState ->
-                when (currentState) {
-                    is HomeUiState.Success -> currentState.copy(isStudyRoomExtendDialog = isVisible)
-                    else -> currentState
-                }
-            }
-        }
-
-        fun updateStudyRoomEndDialogVisibility(isVisible: Boolean) {
-            _homeUiState.update { currentState ->
-                when (currentState) {
-                    is HomeUiState.Success -> currentState.copy(isStudyRoomEndDialog = isVisible)
-                    else -> currentState
+    fun saveStudyDay(isExtend: Boolean) {
+        val currentState = _homeUiState.value
+        if (currentState is HomeUiState.Success) {
+            viewModelScope.launch {
+                studyDayRepository.saveStudyDay(
+                    currentState.timerUiModel.startDateTime,
+                    LocalDateTime.now(),
+                ).onSuccess {
+                    if (!isExtend) loadHomeData()
+                }.onFailure { throwable ->
+                    _errorFlow.emit(throwable)
                 }
             }
         }
     }
+
+    fun updateTimerStateFromTimerViewModel(timerState: TimerUiModel) {
+        _homeUiState.update { currentState ->
+            when (currentState) {
+                is HomeUiState.Success -> {
+                    currentState.copy(
+                        timerUiModel = timerState,
+                    )
+                }
+
+                else -> currentState
+            }
+        }
+    }
+
+    fun updateTimePickerVisibility(isVisible: Boolean) {
+        _homeUiState.update { currentState ->
+            when (currentState) {
+                is HomeUiState.Success -> currentState.copy(isTimePickerVisible = isVisible)
+                else -> currentState
+            }
+        }
+    }
+
+    fun updateTimerRunning(isTimerRunning: Boolean) {
+        _homeUiState.update { currentState ->
+            when (currentState) {
+                is HomeUiState.Success -> currentState.copy(isTimerRunning = isTimerRunning)
+                else -> currentState
+            }
+        }
+    }
+
+    fun updateSelectedTime(selectedTime: LocalDateTime) {
+        _homeUiState.update { currentState ->
+            when (currentState) {
+                is HomeUiState.Success -> currentState.copy(selectedTime = selectedTime)
+                else -> currentState
+            }
+        }
+    }
+
+    fun updateStudyRoomExtendDialogVisibility(isVisible: Boolean) {
+        _homeUiState.update { currentState ->
+            when (currentState) {
+                is HomeUiState.Success -> currentState.copy(isStudyRoomExtendDialog = isVisible)
+                else -> currentState
+            }
+        }
+    }
+
+    fun updateStudyRoomEndDialogVisibility(isVisible: Boolean) {
+        _homeUiState.update { currentState ->
+            when (currentState) {
+                is HomeUiState.Success -> currentState.copy(isStudyRoomEndDialog = isVisible)
+                else -> currentState
+            }
+        }
+    }
+}

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/model/HomeUiState.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/model/HomeUiState.kt
@@ -1,6 +1,6 @@
 package com.teamhy2.feature.home.model
 
-import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerUiModel
+import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerUiState
 import com.teamhy2.main.domain.model.WeeklyStudyDay
 import com.teamhy2.main.domain.model.WiseSaying
 import java.time.LocalDateTime
@@ -16,7 +16,7 @@ sealed interface HomeUiState {
         val isStudyRoomEndDialog: Boolean = false,
         val selectedTime: LocalDateTime = LocalDateTime.now(),
         val isTimerRunning: Boolean = false,
-        val timerUiModel: TimerUiModel = TimerUiModel(),
+        val timerUiState: TimerUiState = TimerUiState(),
     ) : HomeUiState
 
     data class Error(val message: String?) : HomeUiState

--- a/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/TimerService.kt
+++ b/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/TimerService.kt
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 
 interface TimerService {
     fun startService(
-        startTime: LocalDateTime,
+        startDateTime: LocalDateTime,
         duration: Duration,
     )
 

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerForegroundService.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerForegroundService.kt
@@ -117,12 +117,12 @@ class TimerForegroundService
         }
 
         override fun startService(
-            startTime: LocalDateTime,
+            startDateTime: LocalDateTime,
             duration: Duration,
         ) {
             val appContext: Context = context.applicationContext
             val startTimeMillis: Long =
-                startTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+                startDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
 
             val startIntent: Intent =
                 Intent(appContext, TimerForegroundService::class.java).apply {

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
@@ -53,14 +53,15 @@ class TimerViewModel
         }
 
         fun setTimer(
-            startTime: LocalDateTime,
+            startDateTime: LocalDateTime,
             duration: Duration = durationHour.value,
             events: Map<Long, () -> Unit>,
         ) {
             timerJob?.cancel()
-            timer = Timer(startTime, duration, events)
+            timer = Timer(startDateTime, duration, events)
             _timerState.value =
                 TimerUiModel(
+                    startDateTime = startDateTime,
                     startTime = timer.formattedStartTime,
                     startTimeMeridiem = timer.formattedStartTimeMeridiem,
                     endTime = timer.formattedEndTime,

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.teamhy2.hongikyeolgong2.timer.model.Timer
 import com.teamhy2.hongikyeolgong2.timer.model.TimerRepository
-import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerUiModel
+import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -27,8 +27,8 @@ class TimerViewModel
         private lateinit var timer: Timer
         private var timerJob: Job? = null
 
-        private val _timerState = MutableStateFlow(TimerUiModel())
-        val timerState: StateFlow<TimerUiModel> = _timerState.asStateFlow()
+        private val _timerState = MutableStateFlow(TimerUiState())
+        val timerState: StateFlow<TimerUiState> = _timerState.asStateFlow()
 
         private val _durationHour: MutableStateFlow<Duration> = MutableStateFlow(Duration.ZERO)
         val durationHour: StateFlow<Duration> = _durationHour.asStateFlow()
@@ -60,7 +60,7 @@ class TimerViewModel
             timerJob?.cancel()
             timer = Timer(startDateTime, duration, events)
             _timerState.value =
-                TimerUiModel(
+                TimerUiState(
                     startDateTime = startDateTime,
                     startTime = timer.formattedStartTime,
                     startTimeMeridiem = timer.formattedStartTimeMeridiem,

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/TimerUiModel.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/TimerUiModel.kt
@@ -1,6 +1,9 @@
 package com.teamhy2.hongikyeolgong2.timer.presentation.model
 
+import java.time.LocalDateTime
+
 data class TimerUiModel(
+    val startDateTime: LocalDateTime = LocalDateTime.now(),
     val startTime: String = "",
     val startTimeMeridiem: String = "",
     val endTime: String = "",

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/TimerUiState.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/TimerUiState.kt
@@ -2,7 +2,7 @@ package com.teamhy2.hongikyeolgong2.timer.presentation.model
 
 import java.time.LocalDateTime
 
-data class TimerUiModel(
+data class TimerUiState(
     val startDateTime: LocalDateTime = LocalDateTime.now(),
     val startTime: String = "",
     val startTimeMeridiem: String = "",


### PR DESCRIPTION
resolved #147 
resolved #148 

## AS-IS
- 자정이 지나서 열람실 이용을 종료한다면 시작날짜가 종료날짜와 동일하게 나오는 현상 발생
- `12월 4일 오전 1시`에 `12월 3일 오후 23시 50분`을 고르면 `12월 4일 오후 23시 50분`이 선택되는 현상 발생

## TO-BE
- 열람실 이용 종료시 저장해둔 시작날짜를 불러오는 로직으로 수정하여 시작날짜가 올바르게 전송됩니다.
- `HY2TimePicker`가 어제 날짜인지 판단하여 날짜를 보정합니다.

## KEY-POINT
- `startTime`변수가 `LocalDateTime`자료형인데 Time이라는 이름만 사용하는 것은 적절하지 않다고 생각하여 변수 이름을 변경하였습니다.
- `parseStartTimeToLocalDateTime`라는 함수는 `HY2TimePicker`가 앞의 함수 기능을 수행하기 때문에 제거하였습니다.

## SCREENSHOT (Optional)

https://github.com/user-attachments/assets/bebb2817-57fb-461c-8788-ad0dc37c256e





