### PR TITLE
[Feature] 주요 서버통신 이벤트에 Throttle를 적용합니다.

### DIFF
--- a/core/auth/src/main/java/com/teamhy2/core/auth/GoogleSignInButton.kt
+++ b/core/auth/src/main/java/com/teamhy2/core/auth/GoogleSignInButton.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,25 +16,35 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.teamhy2.designsystem.common.ThrottledButton
 import com.teamhy2.designsystem.ui.theme.Gray800
 import com.teamhy2.designsystem.ui.theme.HY2Theme
 import com.teamhy2.designsystem.ui.theme.HY2Typography
 import com.teamhy2.designsystem.ui.theme.White
+import com.teamhy2.designsystem.util.modifier.throttleClick
 
 @Composable
 fun GoogleSignInButton(
     onGoogleSignInClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Button(
+    ThrottledButton(
         onClick = onGoogleSignInClick,
-        modifier = modifier.height(50.dp),
+        modifier = modifier
+            .height(50.dp)
+            .throttleClick {
+                onGoogleSignInClick()
+            },
         shape = RoundedCornerShape(8.dp),
         contentPadding = PaddingValues(horizontal = 20.dp),
         colors = ButtonDefaults.buttonColors().copy(containerColor = White),
     ) {
         Box(modifier = Modifier.weight(1f)) {
-            Image(painter = painterResource(id = R.drawable.logo_google), contentDescription = null, modifier = Modifier.size(24.dp))
+            Image(
+                painter = painterResource(id = R.drawable.logo_google),
+                contentDescription = null,
+                modifier = Modifier.size(24.dp)
+            )
         }
         Text(
             text = stringResource(R.string.google_sign_in_text),

--- a/core/auth/src/main/java/com/teamhy2/core/auth/GoogleSignInButton.kt
+++ b/core/auth/src/main/java/com/teamhy2/core/auth/GoogleSignInButton.kt
@@ -38,7 +38,7 @@ fun GoogleSignInButton(
             Image(
                 painter = painterResource(id = R.drawable.logo_google),
                 contentDescription = null,
-                modifier = Modifier.size(24.dp)
+                modifier = Modifier.size(24.dp),
             )
         }
         Text(

--- a/core/auth/src/main/java/com/teamhy2/core/auth/GoogleSignInButton.kt
+++ b/core/auth/src/main/java/com/teamhy2/core/auth/GoogleSignInButton.kt
@@ -21,7 +21,6 @@ import com.teamhy2.designsystem.ui.theme.Gray800
 import com.teamhy2.designsystem.ui.theme.HY2Theme
 import com.teamhy2.designsystem.ui.theme.HY2Typography
 import com.teamhy2.designsystem.ui.theme.White
-import com.teamhy2.designsystem.util.modifier.throttleClick
 
 @Composable
 fun GoogleSignInButton(
@@ -30,11 +29,7 @@ fun GoogleSignInButton(
 ) {
     ThrottledButton(
         onClick = onGoogleSignInClick,
-        modifier = modifier
-            .height(50.dp)
-            .throttleClick {
-                onGoogleSignInClick()
-            },
+        modifier = modifier.height(50.dp),
         shape = RoundedCornerShape(8.dp),
         contentPadding = PaddingValues(horizontal = 20.dp),
         colors = ButtonDefaults.buttonColors().copy(containerColor = White),

--- a/core/auth/src/main/java/com/teamhy2/core/auth/GoogleSignInButton.kt
+++ b/core/auth/src/main/java/com/teamhy2/core/auth/GoogleSignInButton.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.teamhy2.designsystem.common.ThrottledButton
+import com.teamhy2.designsystem.common.ThrottleButton
 import com.teamhy2.designsystem.ui.theme.Gray800
 import com.teamhy2.designsystem.ui.theme.HY2Theme
 import com.teamhy2.designsystem.ui.theme.HY2Typography
@@ -27,7 +27,7 @@ fun GoogleSignInButton(
     onGoogleSignInClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    ThrottledButton(
+    ThrottleButton(
         onClick = onGoogleSignInClick,
         modifier = modifier.height(50.dp),
         shape = RoundedCornerShape(8.dp),

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
@@ -3,7 +3,6 @@ package com.teamhy2.designsystem.common
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,18 +27,18 @@ fun HY2Button(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Button(
+    ThrottledButton(
         onClick = onClick,
         colors =
-            ButtonDefaults.buttonColors(
-                containerColor = backgroundColor,
-                contentColor = textColor,
-            ),
+        ButtonDefaults.buttonColors(
+            containerColor = backgroundColor,
+            contentColor = textColor,
+        ),
         shape = RoundedCornerShape(BUTTON_ROUNDED_CORNER_SIZE),
         modifier =
-            modifier
-                .fillMaxWidth()
-                .height(BUTTON_HEIGHT.dp),
+        modifier
+            .fillMaxWidth()
+            .height(BUTTON_HEIGHT.dp),
     ) {
         Text(
             text = text,

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
@@ -27,7 +27,7 @@ fun HY2Button(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    ThrottledButton(
+    ThrottleButton(
         onClick = onClick,
         colors =
             ButtonDefaults.buttonColors(

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Button.kt
@@ -30,15 +30,15 @@ fun HY2Button(
     ThrottledButton(
         onClick = onClick,
         colors =
-        ButtonDefaults.buttonColors(
-            containerColor = backgroundColor,
-            contentColor = textColor,
-        ),
+            ButtonDefaults.buttonColors(
+                containerColor = backgroundColor,
+                contentColor = textColor,
+            ),
         shape = RoundedCornerShape(BUTTON_ROUNDED_CORNER_SIZE),
         modifier =
-        modifier
-            .fillMaxWidth()
-            .height(BUTTON_HEIGHT.dp),
+            modifier
+                .fillMaxWidth()
+                .height(BUTTON_HEIGHT.dp),
     ) {
         Text(
             text = text,

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
@@ -118,7 +118,7 @@ internal fun HY2DialogButton(
     textColor: Color,
     modifier: Modifier = Modifier,
 ) {
-    ThrottledButton(
+    ThrottleButton(
         onClick = onClick,
         colors = ButtonDefaults.buttonColors(containerColor = buttonColor),
         shape = RoundedCornerShape(BUTTON_CORNER_RADIUS.dp),

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
@@ -119,7 +119,7 @@ internal fun HY2DialogButton(
     textColor: Color,
     modifier: Modifier = Modifier,
 ) {
-    Button(
+    ThrottledButton(
         onClick = onClick,
         colors = ButtonDefaults.buttonColors(containerColor = buttonColor),
         shape = RoundedCornerShape(BUTTON_CORNER_RADIUS.dp),

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/ThrottleButton.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/ThrottleButton.kt
@@ -13,7 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 
-const val DEFAULT_THROTTLE_TIME = 1000L
+private const val DEFAULT_THROTTLE_TIME = 1000L
 
 @Composable
 fun ThrottleButton(

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/ThrottleButton.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/ThrottleButton.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ButtonElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
@@ -29,17 +30,15 @@ fun ThrottleButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable RowScope.() -> Unit,
 ) {
-    val throttledClick =
-        remember(throttleTime) {
-            var lastClickTime: Long = 0L
-            {
-                val currentTime: Long = System.currentTimeMillis()
-                if (currentTime - lastClickTime >= throttleTime) {
-                    onClick()
-                    lastClickTime = currentTime
-                }
-            }
+    val lastClickTime = remember { mutableLongStateOf(0L) }
+
+    val throttledClick: () -> Unit = {
+        val currentTime: Long = System.currentTimeMillis()
+        if (currentTime - lastClickTime.longValue >= throttleTime) {
+            onClick()
+            lastClickTime.longValue = currentTime
         }
+    }
 
     Button(
         onClick = throttledClick,

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/ThrottleButton.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/ThrottleButton.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.graphics.Shape
 const val DEFAULT_THROTTLE_TIME = 1000L
 
 @Composable
-fun ThrottledButton(
+fun ThrottleButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     throttleTime: Long = DEFAULT_THROTTLE_TIME,

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/ThrottledButton.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/ThrottledButton.kt
@@ -29,16 +29,17 @@ fun ThrottledButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable RowScope.() -> Unit,
 ) {
-    val throttledClick = remember(throttleTime) {
-        var lastClickTime: Long = 0L
-        {
-            val currentTime: Long = System.currentTimeMillis()
-            if (currentTime - lastClickTime >= throttleTime) {
-                onClick()
-                lastClickTime = currentTime
+    val throttledClick =
+        remember(throttleTime) {
+            var lastClickTime: Long = 0L
+            {
+                val currentTime: Long = System.currentTimeMillis()
+                if (currentTime - lastClickTime >= throttleTime) {
+                    onClick()
+                    lastClickTime = currentTime
+                }
             }
         }
-    }
 
     Button(
         onClick = throttledClick,
@@ -53,4 +54,3 @@ fun ThrottledButton(
         content = content,
     )
 }
-

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/ThrottledButton.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/ThrottledButton.kt
@@ -1,0 +1,56 @@
+package com.teamhy2.designsystem.common
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ButtonElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+
+const val DEFAULT_THROTTLE_TIME = 1000L
+
+@Composable
+fun ThrottledButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    throttleTime: Long = DEFAULT_THROTTLE_TIME,
+    enabled: Boolean = true,
+    shape: Shape = ButtonDefaults.shape,
+    colors: ButtonColors = ButtonDefaults.buttonColors(),
+    elevation: ButtonElevation? = ButtonDefaults.buttonElevation(),
+    border: BorderStroke? = null,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    content: @Composable RowScope.() -> Unit,
+) {
+    val throttledClick = remember(throttleTime) {
+        var lastClickTime: Long = 0L
+        {
+            val currentTime: Long = System.currentTimeMillis()
+            if (currentTime - lastClickTime >= throttleTime) {
+                onClick()
+                lastClickTime = currentTime
+            }
+        }
+    }
+
+    Button(
+        onClick = throttledClick,
+        modifier = modifier,
+        enabled = enabled,
+        shape = shape,
+        colors = colors,
+        elevation = elevation,
+        border = border,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        content = content,
+    )
+}
+

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/util/modifier/ThrottleClick.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/util/modifier/ThrottleClick.kt
@@ -1,0 +1,31 @@
+package com.teamhy2.designsystem.util.modifier
+
+import androidx.compose.foundation.clickable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableLongState
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+
+const val DEFAULT_THROTTLE_TIME = 1000L
+
+@Composable
+fun Modifier.throttleClick(
+    throttleTime: Long = DEFAULT_THROTTLE_TIME,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+): Modifier {
+    val lastClickTime: MutableLongState = remember { mutableLongStateOf(0L) }
+
+    return if (enabled) {
+        this.clickable {
+            val currentTime: Long = System.currentTimeMillis()
+            if (currentTime - lastClickTime.longValue >= throttleTime) {
+                onClick()
+                lastClickTime.longValue = currentTime
+            }
+        }
+    } else {
+        this
+    }
+}

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/util/modifier/ThrottleClick.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/util/modifier/ThrottleClick.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 
-const val DEFAULT_THROTTLE_TIME = 1000L
+private const val DEFAULT_THROTTLE_TIME = 1000L
 
 @Composable
 fun Modifier.throttleClickable(

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/util/modifier/ThrottleClick.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/util/modifier/ThrottleClick.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Modifier
 const val DEFAULT_THROTTLE_TIME = 1000L
 
 @Composable
-fun Modifier.throttleClick(
+fun Modifier.throttleClickable(
     throttleTime: Long = DEFAULT_THROTTLE_TIME,
     enabled: Boolean = true,
     onClick: () -> Unit,

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/util/modifier/ThrottleClick.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/util/modifier/ThrottleClick.kt
@@ -15,17 +15,14 @@ fun Modifier.throttleClickable(
     enabled: Boolean = true,
     onClick: () -> Unit,
 ): Modifier {
+    if (!enabled) return this
+
     val lastClickTime: MutableLongState = remember { mutableLongStateOf(0L) }
 
-    return if (enabled) {
-        this.clickable {
-            val currentTime: Long = System.currentTimeMillis()
-            if (currentTime - lastClickTime.longValue >= throttleTime) {
-                onClick()
-                lastClickTime.longValue = currentTime
-            }
-        }
-    } else {
-        this
+    return this.clickable {
+        val currentTime: Long = System.currentTimeMillis()
+        if (currentTime - lastClickTime.longValue < throttleTime) return@clickable
+        onClick()
+        lastClickTime.longValue = currentTime
     }
 }

--- a/onboarding-presentation/src/main/java/com/teamhy2/onboarding/SignUpScreen.kt
+++ b/onboarding-presentation/src/main/java/com/teamhy2/onboarding/SignUpScreen.kt
@@ -108,16 +108,16 @@ fun SignUpScreen(
 
     Column(
         modifier =
-        modifier
-            .background(BackgroundBlack)
-            .addFocusCleaner(focusManager)
-            .padding(horizontal = 32.dp),
+            modifier
+                .background(BackgroundBlack)
+                .addFocusCleaner(focusManager)
+                .padding(horizontal = 32.dp),
     ) {
         Box(
             modifier =
-            Modifier
-                .fillMaxWidth()
-                .height(52.dp),
+                Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
             contentAlignment = Alignment.CenterStart,
         ) {
             Text(
@@ -144,10 +144,10 @@ fun SignUpScreen(
             Spacer(modifier = Modifier.width(12.dp))
             ThrottledButton(
                 colors =
-                ButtonDefaults.buttonColors(
-                    containerColor = Blue100,
-                    disabledContainerColor = Blue400,
-                ),
+                    ButtonDefaults.buttonColors(
+                        containerColor = Blue100,
+                        disabledContainerColor = Blue400,
+                    ),
                 shape = RoundedCornerShape(8.dp),
                 onClick = onNicknameDuplicateCheckClicked,
                 enabled = isNicknameValidate && nicknameState == NicknameState.NOT_CHECKED,
@@ -157,42 +157,42 @@ fun SignUpScreen(
                     text = stringResource(R.string.sign_up_duplication_check),
                     style = HY2Typography().body05,
                     color =
-                    if (nicknameState == NicknameState.DUPLICATED ||
-                        nicknameState == NicknameState.NOT_DUPLICATED ||
-                        isNicknameValidate.not()
-                    ) {
-                        White.copy(
-                            alpha = 0.4f,
-                        )
-                    } else {
-                        White
-                    },
+                        if (nicknameState == NicknameState.DUPLICATED ||
+                            nicknameState == NicknameState.NOT_DUPLICATED ||
+                            isNicknameValidate.not()
+                        ) {
+                            White.copy(
+                                alpha = 0.4f,
+                            )
+                        } else {
+                            White
+                        },
                 )
             }
         }
         Spacer(modifier = Modifier.height(4.dp))
         Text(
             text =
-            when {
-                nickname.isEmpty() -> stringResource(id = R.string.sign_up_nickname_hint_text)
-                nicknameState == NicknameState.DUPLICATED -> stringResource(id = R.string.sign_up_nickname_duplicated)
-                isNicknameValidate && nicknameState == NicknameState.NOT_CHECKED ->
-                    stringResource(
-                        id = R.string.sign_up_nickname_hint_text,
-                    )
+                when {
+                    nickname.isEmpty() -> stringResource(id = R.string.sign_up_nickname_hint_text)
+                    nicknameState == NicknameState.DUPLICATED -> stringResource(id = R.string.sign_up_nickname_duplicated)
+                    isNicknameValidate && nicknameState == NicknameState.NOT_CHECKED ->
+                        stringResource(
+                            id = R.string.sign_up_nickname_hint_text,
+                        )
 
-                isNicknameValidate -> stringResource(id = R.string.sign_up_nickname_can_use_text)
-                else -> stringResource(R.string.sign_up_nickname_error_text)
-            },
+                    isNicknameValidate -> stringResource(id = R.string.sign_up_nickname_can_use_text)
+                    else -> stringResource(R.string.sign_up_nickname_error_text)
+                },
             style = HY2Typography().caption,
             color =
-            if (nickname.isBlank()) {
-                Gray400
-            } else if (isNicknameValidate.not() || nicknameState == NicknameState.DUPLICATED) {
-                Yellow300
-            } else {
-                Blue100
-            },
+                if (nickname.isBlank()) {
+                    Gray400
+                } else if (isNicknameValidate.not() || nicknameState == NicknameState.DUPLICATED) {
+                    Yellow300
+                } else {
+                    Blue100
+                },
         )
         Spacer(modifier = Modifier.height(32.dp))
         Text(
@@ -231,19 +231,19 @@ private fun HY2GradientMainButton(
     Box(
         contentAlignment = Alignment.Center,
         modifier =
-        modifier
-            .fillMaxWidth()
-            .paint(
-                painter =
-                painterResource(
-                    id = if (enabled) R.drawable.img_gradient_main_button_enabled else R.drawable.img_gradient_main_button_disabled,
+            modifier
+                .fillMaxWidth()
+                .paint(
+                    painter =
+                        painterResource(
+                            id = if (enabled) R.drawable.img_gradient_main_button_enabled else R.drawable.img_gradient_main_button_disabled,
+                        ),
+                    contentScale = ContentScale.Fit,
+                )
+                .throttleClick(
+                    enabled = enabled,
+                    onClick = onClick,
                 ),
-                contentScale = ContentScale.Fit,
-            )
-            .throttleClick(
-                enabled = enabled,
-                onClick = onClick,
-            ),
     ) {
         Text(
             text = text,

--- a/onboarding-presentation/src/main/java/com/teamhy2/onboarding/SignUpScreen.kt
+++ b/onboarding-presentation/src/main/java/com/teamhy2/onboarding/SignUpScreen.kt
@@ -46,7 +46,7 @@ import com.teamhy2.designsystem.ui.theme.White
 import com.teamhy2.designsystem.ui.theme.Yellow300
 import com.teamhy2.designsystem.util.compositionlocal.LocalShowSnackBar
 import com.teamhy2.designsystem.util.modifier.addFocusCleaner
-import com.teamhy2.designsystem.util.modifier.throttleClick
+import com.teamhy2.designsystem.util.modifier.throttleClickable
 import com.teamhy2.onboarding.presentation.R
 import kotlinx.coroutines.flow.collectLatest
 
@@ -240,7 +240,7 @@ private fun HY2GradientMainButton(
                         ),
                     contentScale = ContentScale.Fit,
                 )
-                .throttleClick(
+                .throttleClickable(
                     enabled = enabled,
                     onClick = onClick,
                 ),

--- a/onboarding-presentation/src/main/java/com/teamhy2/onboarding/SignUpScreen.kt
+++ b/onboarding-presentation/src/main/java/com/teamhy2/onboarding/SignUpScreen.kt
@@ -1,7 +1,6 @@
 package com.teamhy2.onboarding
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -11,7 +10,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,6 +33,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.teamhy2.designsystem.common.HY2DropdownTextField
 import com.teamhy2.designsystem.common.HY2LoadingScreen
 import com.teamhy2.designsystem.common.HY2TextField
+import com.teamhy2.designsystem.common.ThrottledButton
 import com.teamhy2.designsystem.ui.theme.BackgroundBlack
 import com.teamhy2.designsystem.ui.theme.Blue100
 import com.teamhy2.designsystem.ui.theme.Blue400
@@ -47,6 +46,7 @@ import com.teamhy2.designsystem.ui.theme.White
 import com.teamhy2.designsystem.ui.theme.Yellow300
 import com.teamhy2.designsystem.util.compositionlocal.LocalShowSnackBar
 import com.teamhy2.designsystem.util.modifier.addFocusCleaner
+import com.teamhy2.designsystem.util.modifier.throttleClick
 import com.teamhy2.onboarding.presentation.R
 import kotlinx.coroutines.flow.collectLatest
 
@@ -108,16 +108,16 @@ fun SignUpScreen(
 
     Column(
         modifier =
-            modifier
-                .background(BackgroundBlack)
-                .addFocusCleaner(focusManager)
-                .padding(horizontal = 32.dp),
+        modifier
+            .background(BackgroundBlack)
+            .addFocusCleaner(focusManager)
+            .padding(horizontal = 32.dp),
     ) {
         Box(
             modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .height(52.dp),
+            Modifier
+                .fillMaxWidth()
+                .height(52.dp),
             contentAlignment = Alignment.CenterStart,
         ) {
             Text(
@@ -142,12 +142,12 @@ fun SignUpScreen(
                 isInvalid = isNicknameValidate.not() || nicknameState == NicknameState.DUPLICATED,
             )
             Spacer(modifier = Modifier.width(12.dp))
-            Button(
+            ThrottledButton(
                 colors =
-                    ButtonDefaults.buttonColors(
-                        containerColor = Blue100,
-                        disabledContainerColor = Blue400,
-                    ),
+                ButtonDefaults.buttonColors(
+                    containerColor = Blue100,
+                    disabledContainerColor = Blue400,
+                ),
                 shape = RoundedCornerShape(8.dp),
                 onClick = onNicknameDuplicateCheckClicked,
                 enabled = isNicknameValidate && nicknameState == NicknameState.NOT_CHECKED,
@@ -157,42 +157,42 @@ fun SignUpScreen(
                     text = stringResource(R.string.sign_up_duplication_check),
                     style = HY2Typography().body05,
                     color =
-                        if (nicknameState == NicknameState.DUPLICATED ||
-                            nicknameState == NicknameState.NOT_DUPLICATED ||
-                            isNicknameValidate.not()
-                        ) {
-                            White.copy(
-                                alpha = 0.4f,
-                            )
-                        } else {
-                            White
-                        },
+                    if (nicknameState == NicknameState.DUPLICATED ||
+                        nicknameState == NicknameState.NOT_DUPLICATED ||
+                        isNicknameValidate.not()
+                    ) {
+                        White.copy(
+                            alpha = 0.4f,
+                        )
+                    } else {
+                        White
+                    },
                 )
             }
         }
         Spacer(modifier = Modifier.height(4.dp))
         Text(
             text =
-                when {
-                    nickname.isEmpty() -> stringResource(id = R.string.sign_up_nickname_hint_text)
-                    nicknameState == NicknameState.DUPLICATED -> stringResource(id = R.string.sign_up_nickname_duplicated)
-                    isNicknameValidate && nicknameState == NicknameState.NOT_CHECKED ->
-                        stringResource(
-                            id = R.string.sign_up_nickname_hint_text,
-                        )
+            when {
+                nickname.isEmpty() -> stringResource(id = R.string.sign_up_nickname_hint_text)
+                nicknameState == NicknameState.DUPLICATED -> stringResource(id = R.string.sign_up_nickname_duplicated)
+                isNicknameValidate && nicknameState == NicknameState.NOT_CHECKED ->
+                    stringResource(
+                        id = R.string.sign_up_nickname_hint_text,
+                    )
 
-                    isNicknameValidate -> stringResource(id = R.string.sign_up_nickname_can_use_text)
-                    else -> stringResource(R.string.sign_up_nickname_error_text)
-                },
+                isNicknameValidate -> stringResource(id = R.string.sign_up_nickname_can_use_text)
+                else -> stringResource(R.string.sign_up_nickname_error_text)
+            },
             style = HY2Typography().caption,
             color =
-                if (nickname.isBlank()) {
-                    Gray400
-                } else if (isNicknameValidate.not() || nicknameState == NicknameState.DUPLICATED) {
-                    Yellow300
-                } else {
-                    Blue100
-                },
+            if (nickname.isBlank()) {
+                Gray400
+            } else if (isNicknameValidate.not() || nicknameState == NicknameState.DUPLICATED) {
+                Yellow300
+            } else {
+                Blue100
+            },
         )
         Spacer(modifier = Modifier.height(32.dp))
         Text(
@@ -231,19 +231,19 @@ private fun HY2GradientMainButton(
     Box(
         contentAlignment = Alignment.Center,
         modifier =
-            modifier
-                .fillMaxWidth()
-                .paint(
-                    painter =
-                        painterResource(
-                            id = if (enabled) R.drawable.img_gradient_main_button_enabled else R.drawable.img_gradient_main_button_disabled,
-                        ),
-                    contentScale = ContentScale.Fit,
-                )
-                .clickable(
-                    enabled = enabled,
-                    onClick = onClick,
+        modifier
+            .fillMaxWidth()
+            .paint(
+                painter =
+                painterResource(
+                    id = if (enabled) R.drawable.img_gradient_main_button_enabled else R.drawable.img_gradient_main_button_disabled,
                 ),
+                contentScale = ContentScale.Fit,
+            )
+            .throttleClick(
+                enabled = enabled,
+                onClick = onClick,
+            ),
     ) {
         Text(
             text = text,

--- a/onboarding-presentation/src/main/java/com/teamhy2/onboarding/SignUpScreen.kt
+++ b/onboarding-presentation/src/main/java/com/teamhy2/onboarding/SignUpScreen.kt
@@ -33,7 +33,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.teamhy2.designsystem.common.HY2DropdownTextField
 import com.teamhy2.designsystem.common.HY2LoadingScreen
 import com.teamhy2.designsystem.common.HY2TextField
-import com.teamhy2.designsystem.common.ThrottledButton
+import com.teamhy2.designsystem.common.ThrottleButton
 import com.teamhy2.designsystem.ui.theme.BackgroundBlack
 import com.teamhy2.designsystem.ui.theme.Blue100
 import com.teamhy2.designsystem.ui.theme.Blue400
@@ -142,7 +142,7 @@ fun SignUpScreen(
                 isInvalid = isNicknameValidate.not() || nicknameState == NicknameState.DUPLICATED,
             )
             Spacer(modifier = Modifier.width(12.dp))
-            ThrottledButton(
+            ThrottleButton(
                 colors =
                     ButtonDefaults.buttonColors(
                         containerColor = Blue100,


### PR DESCRIPTION
resolved #150 

## AS-IS
- 서버통신이 느리거나 버튼을 빠르게 두번 누르게 되면 불필요하고 의도하지 않은 서버통신을 두번 이상 진행하는 경우가 있었습니다.
<img width="483" alt="image" src="https://github.com/user-attachments/assets/0469f0ad-7116-44a0-938f-52e38d757478">

## TO-BE
- throttle를 적용하여 해당 문제를 해결하였습니다.

## KEY-POINT

### Throttle 처리를 해준 이벤트
- 구글 로그인 버튼 클릭
- 회원가입 버튼 클릭
- 닉네임 중복 확인 버튼 클릭
- HY2Button 공통 컴포넌트 버튼 클릭
- HY2DialogButton 버튼 클릭

주로 서버통신과 관련이 있는 버튼을 처리해주었습니다.

### Modifier.throttleClick
- `Modifier`의 확장함수로서 Text 혹은 버튼 이외에 쓰로틀 클릭 처리에 사용됩니다.

### ThrottledButton을 만든 이유
- Button은 onClick이 필수 파라미터이기 때문에 위의 확장함수만으로는 대체가 불가능 하였습니다.
- 그래서 기존의 Button을 완벽하게 대체하면서 쓰로틀 기능을 가진 컴포넌트를 만들었습니다. Button 컴포저블 함수 생성자에 있는 모든 파라미터를 받고 기본값을 동일하게 설정하였으며 기존 Button을 완벽하게 대체하는 모습을 볼 수 있었습니다.

## SCREENSHOT (Optional)
