### PR TITLE
[Fix] PromotionPopup Active 날짜 계산 로직 개선

### DIFF
--- a/main-data/src/main/java/com/teamhy2/main/data/datasource/RemoteConfigPromotionDataSource.kt
+++ b/main-data/src/main/java/com/teamhy2/main/data/datasource/RemoteConfigPromotionDataSource.kt
@@ -10,8 +10,6 @@ import com.teamhy2.main.domain.model.Promotion
 import com.teamhy2.main.domain.util.DateUtil
 import kotlinx.coroutines.tasks.await
 import kotlinx.serialization.json.Json
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 class RemoteConfigPromotionDataSource
@@ -30,25 +28,12 @@ class RemoteConfigPromotionDataSource
                 val promotionDto: PromotionDto = Json.decodeFromString(promotionDataJson)
                 promotionDto.copy(
                     isActive =
-                        calculatePromotionActive(
-                            promotionDto.startDate,
-                            promotionDto.endDate,
+                        DateUtil.isTodayWithinDateRange(
+                            startDateString = promotionDto.startDate,
+                            endDateString = promotionDto.endDate,
                         ),
                 ).toDomain()
             }
-        }
-
-        private fun calculatePromotionActive(
-            startDate: String,
-            endDate: String,
-        ): Boolean {
-            return runCatching {
-                val formatter: DateTimeFormatter = DateTimeFormatter.ISO_DATE
-                val startDate: LocalDate = LocalDate.parse(startDate, formatter)
-                val endDate: LocalDate = LocalDate.parse(endDate, formatter)
-
-                DateUtil.isTodayWithinDateRange(startDate = startDate, endDate = endDate)
-            }.getOrDefault(false)
         }
 
         companion object {

--- a/main-data/src/main/java/com/teamhy2/main/data/datastore/PromotionDataStore.kt
+++ b/main-data/src/main/java/com/teamhy2/main/data/datastore/PromotionDataStore.kt
@@ -23,13 +23,9 @@ class PromotionDataStore
             dataStore.data.map { preferences ->
                 val startDateString: String? = preferences[START_DATE]
                 val endDateString: String? = preferences[END_DATE]
-                requireNotNull(startDateString) { ERROR_START_DATE_MISSING }
-                requireNotNull(endDateString) { ERROR_END_DATE_MISSING }
+                if (startDateString == null || endDateString == null) return@map false
 
-                val startDate: LocalDate = LocalDate.parse(startDateString, formatter)
-                val endDate: LocalDate = LocalDate.parse(endDateString, formatter)
-
-                DateUtil.isTodayWithinDateRange(startDate = startDate, endDate = endDate)
+                DateUtil.isTodayWithinDateRange(startDateString = startDateString, endDateString = endDateString)
             }
 
         suspend fun savePromotionDismissPeriod(
@@ -45,9 +41,6 @@ class PromotionDataStore
         companion object Keys {
             private const val PROMOTION_START_DATE_KEY = "promotion_start_date"
             private const val PROMOTION_END_DATE_KEY = "promotion_end_date"
-
-            const val ERROR_START_DATE_MISSING = "DataStore에 시작 날짜가 없습니다."
-            const val ERROR_END_DATE_MISSING = "DataStore에 종료 날짜가 없습니다."
 
             val START_DATE: Preferences.Key<String> =
                 stringPreferencesKey(PROMOTION_START_DATE_KEY)

--- a/main-domain/src/main/java/com/teamhy2/main/domain/util/DateUtil.kt
+++ b/main-domain/src/main/java/com/teamhy2/main/domain/util/DateUtil.kt
@@ -1,21 +1,41 @@
 package com.teamhy2.main.domain.util
 
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 object DateUtil {
     /**
      * Checks if the current date is within the specified date range.
      *
-     * @param startDate The start date of the range.
-     * @param endDate The end date of the range.
+     * @param startDateString The start date string of the range.
+     * @param endDateString The end date string of the range.
      * @return True if the current date is within the range, false otherwise.
      */
     fun isTodayWithinDateRange(
-        startDate: LocalDate,
-        endDate: LocalDate,
+        startDateString: String,
+        endDateString: String,
     ): Boolean {
-        val today: LocalDate = LocalDate.now()
-        return today.isEqual(startDate) || today.isEqual(endDate) ||
-            (today.isAfter(startDate) && today.isBefore(endDate))
+        val formatter = DateTimeFormatter.ofPattern("[yyyy-MM-dd][yyyy-M-d]")
+
+        val startDateResult =
+            runCatching {
+                LocalDate.parse(startDateString, formatter)
+            }
+
+        val endDateResult =
+            runCatching {
+                LocalDate.parse(endDateString, formatter)
+            }
+
+        if (startDateResult.isFailure || endDateResult.isFailure) {
+            return false
+        }
+
+        val startDate = startDateResult.getOrNull()
+        val endDate = endDateResult.getOrNull()
+        val todayDate: LocalDate = LocalDate.now()
+
+        return todayDate.isEqual(startDate) || todayDate.isEqual(endDate) ||
+            (todayDate.isAfter(startDate) && todayDate.isBefore(endDate))
     }
 }

--- a/main-domain/src/main/java/com/teamhy2/main/domain/util/DateUtil.kt
+++ b/main-domain/src/main/java/com/teamhy2/main/domain/util/DateUtil.kt
@@ -16,23 +16,15 @@ object DateUtil {
         endDateString: String,
     ): Boolean {
         val formatter = DateTimeFormatter.ofPattern("[yyyy-MM-dd][yyyy-M-d]")
-
-        val startDateResult =
+        val startDate =
             runCatching {
                 LocalDate.parse(startDateString, formatter)
-            }
-
-        val endDateResult =
+            }.getOrNull() ?: return false
+        val endDate =
             runCatching {
                 LocalDate.parse(endDateString, formatter)
-            }
+            }.getOrNull() ?: return false
 
-        if (startDateResult.isFailure || endDateResult.isFailure) {
-            return false
-        }
-
-        val startDate = startDateResult.getOrNull()
-        val endDate = endDateResult.getOrNull()
         val todayDate: LocalDate = LocalDate.now()
 
         return todayDate.isEqual(startDate) || todayDate.isEqual(endDate) ||

--- a/main-domain/src/main/java/com/teamhy2/main/domain/util/DateUtil.kt
+++ b/main-domain/src/main/java/com/teamhy2/main/domain/util/DateUtil.kt
@@ -24,7 +24,6 @@ object DateUtil {
             runCatching {
                 LocalDate.parse(endDateString, formatter)
             }.getOrNull() ?: return false
-
         val todayDate: LocalDate = LocalDate.now()
 
         return todayDate.isEqual(startDate) || todayDate.isEqual(endDate) ||

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/HomeViewModel.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/HomeViewModel.kt
@@ -45,8 +45,8 @@ class HomeViewModel
         val errorFlow: SharedFlow<Throwable> = _errorFlow.asSharedFlow()
 
         init {
-            loadHomeData()
             loadPromotionData()
+            loadHomeData()
         }
 
         private fun loadHomeData() {


### PR DESCRIPTION
resolved #154 

## AS-IS
- RemoteConfig를 통해 기존에 `YYYY-M-D` 형식으로 작업을 하였으나 `YYYY-MM-DD` 형식으로 날짜를 넘겨주었을 때 String Format이 정상적으로 이루어지지 않아 문제가 발생하였습니다.

## TO-BE
- 기존 `isTodayWithinDateRange` 함수는 파라미터 자료형이  `LocalDate`로 외부에서 String으로 날짜를 받는다면 `String -> LocalDate` 변환하여 넘겨주어야했습니다.
- DataStore , RemoteConfig 둘다 날짜를 String 형태로 받아오기 때문에 `isTodayWithinDateRange` 파라미터의 자료형을 String으로 받는 것으로 변경하고 혹시 포멧팅이 실패한다면 false를 반환하는 로직을 구현하였습니다.

## KEY-POINT
- RemoteConfig 값을 바꾸고 바로 반영을 원하신다면 앱을 삭제하고 다시 반영해야합니다. RemoteConfig가 일정간격을 가지고 값의 갱신을 시도하는데 지금은 기본값 12시간설정이기 때문입니다.
## SCREENSHOT (Optional)
