### PR TITLE
타이머관련 리팩토링 및 최근앱에서 제거 해도 다시 반영되게 변경

### DIFF
--- a/main-data/src/main/java/com/teamhy2/main/data/repository/RemoteStudyDayRepository.kt
+++ b/main-data/src/main/java/com/teamhy2/main/data/repository/RemoteStudyDayRepository.kt
@@ -32,9 +32,10 @@ class RemoteStudyDayRepository
                     endTime = endDateTime.format(studyDayFormatter),
                 )
 
-            return studyService.postStudyDay(studyDayRequest).toResult { baseResponse ->
-                baseResponse.data.toDomain()
-            }
+            return studyService.postStudyDay(studyDayRequest)
+                .toResult { baseResponse ->
+                    baseResponse.data.toDomain()
+                }
         }
 
         companion object {

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/HomeScreen.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/HomeScreen.kt
@@ -40,7 +40,6 @@ import com.teamhy2.feature.home.component.RunningTimerComponent
 import com.teamhy2.feature.home.component.WeeklyStudyCalendar
 import com.teamhy2.feature.home.model.HomeUiState
 import com.teamhy2.hongikyeolgong2.main.presentation.R
-import com.teamhy2.hongikyeolgong2.timer.model.Timer
 import com.teamhy2.hongikyeolgong2.timer.presentation.TimerViewModel
 import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerUiState
 import com.teamhy2.main.domain.model.WeeklyStudyDay
@@ -107,7 +106,9 @@ fun HomeRoute(
                             isTimePickerVisible = false
                             increaseTodayStudyCount()
                         }
-                        startTimer(selectedDateTime, homeViewModel, timerViewModel)
+                        timerViewModel.setTimer(
+                            startDateTime = selectedDateTime,
+                        )
                         tracker.trackEvent("StudyStartButton")
                     },
                     onCancelled = {
@@ -131,7 +132,10 @@ fun HomeRoute(
                             saveStudyDay((timerState as TimerUiState.Running).startDateTime, true)
                             increaseTodayStudyCount()
                         }
-                        startTimer(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES), homeViewModel, timerViewModel)
+                        timerViewModel
+                            .setTimer(
+                                startDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES),
+                            )
                         timerViewModel.stopTimer()
                         tracker.trackEvent("StudyExtendButton")
                     },
@@ -200,25 +204,6 @@ fun SetNavigationBarColor(color: Color) {
             window.navigationBarColor = color.toArgb()
         }
     }
-}
-
-private fun startTimer(
-    startDateTime: LocalDateTime,
-    homeViewModel: HomeViewModel,
-    timerViewModel: TimerViewModel,
-) {
-    timerViewModel.setTimer(
-        startDateTime = startDateTime,
-        events =
-            mapOf(
-                Timer.TIME_OVER to {
-                    homeViewModel.saveStudyDay(
-                        startDateTime = startDateTime,
-                        isExtend = false,
-                    )
-                },
-            ),
-    )
 }
 
 @Composable

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/HomeScreen.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/HomeScreen.kt
@@ -128,7 +128,7 @@ fun HomeRoute(
                     onRightButtonClick = {
                         isStudyRoomExtendDialog = false
                         homeViewModel.run {
-                            saveStudyDay(timerState.startDateTime, true)
+                            saveStudyDay((timerState as TimerUiState.Running).startDateTime, true)
                             increaseTodayStudyCount()
                         }
                         startTimer(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES), homeViewModel, timerViewModel)
@@ -151,7 +151,7 @@ fun HomeRoute(
                     },
                     onRightButtonClick = {
                         isStudyRoomEndDialog = false
-                        homeViewModel.saveStudyDay(timerState.startDateTime, false)
+                        homeViewModel.saveStudyDay((timerState as TimerUiState.Running).startDateTime, false)
                         timerViewModel.stopTimer()
 
                         tracker.trackEvent("StudyEndButton")
@@ -165,9 +165,7 @@ fun HomeRoute(
             HomeScreen(
                 weeklyStudyDays = uiState.weeklyStudyDays,
                 wiseSaying = uiState.wiseSaying,
-                durationAsSecond = timerState.duration.seconds,
                 timerUiState = timerState,
-                modifier = modifier,
                 onSeatingChartClick = {
                     val intent = Intent(Intent.ACTION_VIEW, Uri.parse(seatingChartUrl))
                     context.startActivity(intent)
@@ -181,6 +179,7 @@ fun HomeRoute(
                 onStudyRoomEndClick = {
                     isStudyRoomEndDialog = true
                 },
+                modifier = modifier,
             )
         }
 
@@ -226,7 +225,6 @@ private fun startTimer(
 fun HomeScreen(
     weeklyStudyDays: List<WeeklyStudyDay>,
     wiseSaying: WiseSaying,
-    durationAsSecond: Long,
     timerUiState: TimerUiState,
     onSeatingChartClick: () -> Unit,
     onStudyRoomStartClick: () -> Unit,
@@ -247,9 +245,7 @@ fun HomeScreen(
         )
         Spacer(modifier = Modifier.height(36.dp))
         HomeBody(
-            durationAsSecond = durationAsSecond,
             wiseSaying = wiseSaying,
-            isTimerRunning = timerUiState.isRunning,
             timerUiState = timerUiState,
             onSeatingChartClick = onSeatingChartClick,
             onStudyRoomStartClick = onStudyRoomStartClick,
@@ -276,9 +272,7 @@ private fun HomeHeader(
 
 @Composable
 private fun HomeBody(
-    durationAsSecond: Long,
     wiseSaying: WiseSaying,
-    isTimerRunning: Boolean,
     timerUiState: TimerUiState,
     onSeatingChartClick: () -> Unit,
     onStudyRoomStartClick: () -> Unit,
@@ -292,22 +286,17 @@ private fun HomeBody(
                 .fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        when (isTimerRunning) {
-            true -> {
+        when (timerUiState) {
+            is TimerUiState.Running -> {
                 RunningTimerComponent(
-                    durationAsSecond = durationAsSecond,
-                    startTime = timerUiState.startTime,
-                    endTime = timerUiState.endTime,
-                    startTimeMeridiem = timerUiState.startTimeMeridiem,
-                    endTimeMeridiem = timerUiState.endTimeMeridiem,
-                    leftTime = timerUiState.leftTime,
+                    timerUiState = timerUiState,
                     onStudyRoomExtendClick = onStudyRoomExtendClick,
                     onStudyRoomEndClick = onStudyRoomEndClick,
                 )
                 Spacer(modifier = Modifier.weight(1f))
             }
 
-            false -> {
+            is TimerUiState.Idle -> {
                 InitTimerComponent(
                     wiseSaying = wiseSaying,
                     onSeatingChartClick = onSeatingChartClick,
@@ -326,12 +315,11 @@ private fun HomeScreenPreview() {
         HomeScreen(
             weeklyStudyDays = WeeklyStudyDay.defaultWeek(),
             wiseSaying = WiseSaying.DEFAULT,
-            durationAsSecond = 0,
+            timerUiState = TimerUiState.Idle,
             onSeatingChartClick = { },
             onStudyRoomStartClick = { },
             onStudyRoomExtendClick = { },
             onStudyRoomEndClick = { },
-            timerUiState = TimerUiState(),
         )
     }
 }

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/HomeScreen.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/HomeScreen.kt
@@ -14,7 +14,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -52,21 +54,22 @@ fun HomeRoute(
     seatingChartUrl: String,
     modifier: Modifier = Modifier,
     homeViewModel: HomeViewModel = hiltViewModel(),
+    timerViewModel: TimerViewModel = hiltViewModel(),
 ) {
     val homeUiState: HomeUiState by homeViewModel.homeUiState.collectAsStateWithLifecycle()
+    val timerState by timerViewModel.timerState.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
-    val timerViewModel: TimerViewModel = hiltViewModel()
-    val timerState by timerViewModel.timerState.collectAsStateWithLifecycle()
-    val duration by timerViewModel.durationHour.collectAsStateWithLifecycle()
     val localShowSnackBar = LocalShowSnackBar.current
     val tracker = LocalTracker.current
-
-    homeViewModel.updateTimerStateFromTimerViewModel(timerState)
 
     var backPressedTime by remember {
         mutableLongStateOf(0L)
     }
+
+    var isTimePickerVisible by rememberSaveable { mutableStateOf(false) }
+    var isStudyRoomExtendDialog by rememberSaveable { mutableStateOf(false) }
+    var isStudyRoomEndDialog by rememberSaveable { mutableStateOf(false) }
 
     BackHandler(enabled = true) {
         if (System.currentTimeMillis() - backPressedTime <= 2000L) {
@@ -96,83 +99,65 @@ fun HomeRoute(
 
         is HomeUiState.Success -> {
             val uiState = homeUiState as HomeUiState.Success
-            if (uiState.isTimePickerVisible) {
+            if (isTimePickerVisible) {
                 HY2TimePicker(
                     title = stringResource(R.string.main_study_room_use_start_time),
                     onSelected = { selectedDateTime ->
                         homeViewModel.run {
-                            updateSelectedTime(selectedDateTime)
-                            updateTimePickerVisibility(false)
-                            updateTimerRunning(true)
+                            isTimePickerVisible = false
                             increaseTodayStudyCount()
                         }
                         startTimer(selectedDateTime, homeViewModel, timerViewModel)
-                        homeViewModel.startTimerService(
-                            startDateTime = selectedDateTime,
-                            duration = timerViewModel.durationHour.value,
-                        )
                         tracker.trackEvent("StudyStartButton")
                     },
                     onCancelled = {
-                        homeViewModel.updateTimePickerVisibility(false)
+                        isTimePickerVisible = false
                     },
                     onDismiss = {
-                        homeViewModel.updateTimePickerVisibility(false)
+                        isTimePickerVisible = false
                     },
                 )
             }
 
-            if (uiState.isStudyRoomExtendDialog) {
+            if (isStudyRoomExtendDialog) {
                 HY2Dialog(
                     description = stringResource(R.string.main_extend_dialog_title),
                     leftButtonText = stringResource(R.string.main_extend_dialog_negative_button),
                     rightButtonText = stringResource(R.string.main_extend_dialog_positive_button),
-                    onLeftButtonClick = {
-                        homeViewModel.updateStudyRoomExtendDialogVisibility(false)
-                    },
+                    onLeftButtonClick = { isStudyRoomExtendDialog = false },
                     onRightButtonClick = {
+                        isStudyRoomExtendDialog = false
                         homeViewModel.run {
-                            updateStudyRoomExtendDialogVisibility(false)
-                            saveStudyDay(true)
-                            updateTimerRunning(true)
-                            updateSelectedTime(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES))
+                            saveStudyDay(timerState.startDateTime, true)
                             increaseTodayStudyCount()
                         }
-                        startTimer(
-                            LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES),
-                            homeViewModel,
-                            timerViewModel,
-                        )
-                        homeViewModel.stopTimerService()
-                        homeViewModel.startTimerService(
-                            startDateTime = LocalDateTime.now(),
-                            duration = timerViewModel.durationHour.value,
-                        )
+                        startTimer(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES), homeViewModel, timerViewModel)
+                        timerViewModel.stopTimer()
                         tracker.trackEvent("StudyExtendButton")
                     },
                     onDismiss = {
-                        homeViewModel.updateStudyRoomExtendDialogVisibility(false)
+                        isStudyRoomExtendDialog = false
                     },
                 )
             }
 
-            if (uiState.isStudyRoomEndDialog) {
+            if (isStudyRoomEndDialog) {
                 HY2Dialog(
                     description = stringResource(R.string.main_end_dialog_title),
                     leftButtonText = stringResource(R.string.main_end_dialog_negative_button),
                     rightButtonText = stringResource(R.string.main_end_dialog_positive_button),
                     onLeftButtonClick = {
-                        homeViewModel.updateStudyRoomEndDialogVisibility(false)
+                        isStudyRoomEndDialog = false
                     },
                     onRightButtonClick = {
-                        homeViewModel.updateStudyRoomEndDialogVisibility(false)
-                        homeViewModel.updateTimerRunning(false)
-                        homeViewModel.saveStudyDay(false)
-                        homeViewModel.stopTimerService()
+                        isStudyRoomEndDialog = false
+                        homeViewModel.saveStudyDay(timerState.startDateTime, false)
+                        timerViewModel.stopTimer()
+
                         tracker.trackEvent("StudyEndButton")
                     },
                     onDismiss = {
-                        homeViewModel.updateStudyRoomEndDialogVisibility(false)
+                        isStudyRoomEndDialog = false
                     },
                 )
             }
@@ -180,22 +165,21 @@ fun HomeRoute(
             HomeScreen(
                 weeklyStudyDays = uiState.weeklyStudyDays,
                 wiseSaying = uiState.wiseSaying,
-                durationAsSecond = duration.seconds,
-                isTimerRunning = uiState.isTimerRunning,
-                timerUiState = uiState.timerUiState,
+                durationAsSecond = timerState.duration.seconds,
+                timerUiState = timerState,
                 modifier = modifier,
                 onSeatingChartClick = {
                     val intent = Intent(Intent.ACTION_VIEW, Uri.parse(seatingChartUrl))
                     context.startActivity(intent)
                 },
                 onStudyRoomStartClick = {
-                    homeViewModel.updateTimePickerVisibility(true)
+                    isTimePickerVisible = true
                 },
                 onStudyRoomExtendClick = {
-                    homeViewModel.updateStudyRoomExtendDialogVisibility(true)
+                    isStudyRoomExtendDialog = true
                 },
                 onStudyRoomEndClick = {
-                    homeViewModel.updateStudyRoomEndDialogVisibility(true)
+                    isStudyRoomEndDialog = true
                 },
             )
         }
@@ -229,8 +213,10 @@ private fun startTimer(
         events =
             mapOf(
                 Timer.TIME_OVER to {
-                    homeViewModel.updateTimerRunning(false)
-                    homeViewModel.saveStudyDay(false)
+                    homeViewModel.saveStudyDay(
+                        startDateTime = startDateTime,
+                        isExtend = false,
+                    )
                 },
             ),
     )
@@ -241,7 +227,6 @@ fun HomeScreen(
     weeklyStudyDays: List<WeeklyStudyDay>,
     wiseSaying: WiseSaying,
     durationAsSecond: Long,
-    isTimerRunning: Boolean,
     timerUiState: TimerUiState,
     onSeatingChartClick: () -> Unit,
     onStudyRoomStartClick: () -> Unit,
@@ -264,7 +249,7 @@ fun HomeScreen(
         HomeBody(
             durationAsSecond = durationAsSecond,
             wiseSaying = wiseSaying,
-            isTimerRunning = isTimerRunning,
+            isTimerRunning = timerUiState.isRunning,
             timerUiState = timerUiState,
             onSeatingChartClick = onSeatingChartClick,
             onStudyRoomStartClick = onStudyRoomStartClick,
@@ -346,7 +331,6 @@ private fun HomeScreenPreview() {
             onStudyRoomStartClick = { },
             onStudyRoomExtendClick = { },
             onStudyRoomEndClick = { },
-            isTimerRunning = false,
             timerUiState = TimerUiState(),
         )
     }

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/HomeScreen.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/HomeScreen.kt
@@ -45,8 +45,6 @@ import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerUiState
 import com.teamhy2.main.domain.model.WeeklyStudyDay
 import com.teamhy2.main.domain.model.WiseSaying
 import kotlinx.coroutines.flow.collectLatest
-import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
 
 @Composable
 fun HomeRoute(
@@ -132,11 +130,7 @@ fun HomeRoute(
                             saveStudyDay((timerState as TimerUiState.Running).startDateTime, true)
                             increaseTodayStudyCount()
                         }
-                        timerViewModel
-                            .setTimer(
-                                startDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES),
-                            )
-                        timerViewModel.stopTimer()
+                        timerViewModel.extendTime()
                         tracker.trackEvent("StudyExtendButton")
                     },
                     onDismiss = {

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/HomeScreen.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/HomeScreen.kt
@@ -128,10 +128,7 @@ fun HomeRoute(
                     onLeftButtonClick = { isStudyRoomExtendDialog = false },
                     onRightButtonClick = {
                         isStudyRoomExtendDialog = false
-                        homeViewModel.run {
-                            saveStudyDay((timerState as TimerUiState.Running).startDateTime, true)
-                            increaseTodayStudyCount()
-                        }
+                        homeViewModel.increaseTodayStudyCount()
                         timerViewModel.extendTime()
                         tracker.trackEvent("StudyExtendButton")
                     },
@@ -151,7 +148,7 @@ fun HomeRoute(
                     },
                     onRightButtonClick = {
                         isStudyRoomEndDialog = false
-                        homeViewModel.saveStudyDay((timerState as TimerUiState.Running).startDateTime, false)
+//                        homeViewModel.saveStudyDay((timerState as TimerUiState.Running).duration, false)
                         timerViewModel.stopTimer()
 
                         tracker.trackEvent("StudyEndButton")

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/HomeViewModel.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package com.teamhy2.feature.home
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.teamhy2.feature.home.model.HomeUiState
@@ -22,7 +23,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
@@ -77,6 +77,7 @@ class HomeViewModel
                     isDismissedFlow.collect { isDismissed ->
                         _homeUiState.update { currentState ->
                             if (currentState is HomeUiState.Success) {
+                                Log.d("bandal", "loadPromotionData: isDismissed = $isDismissed promotion = $promotion")
                                 currentState.copy(
                                     promotion = promotion,
                                     isPromotionDialog = !isDismissed && promotion.isActive,
@@ -88,33 +89,6 @@ class HomeViewModel
                     }
                 }.onFailure { exception ->
                     _errorFlow.emit(exception)
-                }
-            }
-        }
-
-        fun startTimerService(
-            startDateTime: LocalDateTime,
-            duration: Duration,
-        ) {
-            timerService.startService(startDateTime, duration)
-        }
-
-        fun stopTimerService() {
-            timerService.stopService()
-        }
-
-        fun saveStudyDay(isExtend: Boolean) {
-            val currentState = _homeUiState.value
-            if (currentState is HomeUiState.Success) {
-                viewModelScope.launch {
-                    studyDayRepository.saveStudyDay(
-                        startDateTime = currentState.timerUiState.startDateTime,
-                        endDateTime = LocalDateTime.now(),
-                    ).onSuccess {
-                        if (!isExtend) loadHomeData()
-                    }.onFailure { throwable ->
-                        _errorFlow.emit(throwable)
-                    }
                 }
             }
         }
@@ -138,22 +112,6 @@ class HomeViewModel
                     }
 
                     else -> currentState
-                }
-            }
-        }
-
-        fun saveStudyDay(
-            startDateTime: LocalDateTime,
-            isExtend: Boolean,
-        ) {
-            viewModelScope.launch {
-                studyDayRepository.saveStudyDay(
-                    startDateTime = startDateTime,
-                    endDateTime = LocalDateTime.now(),
-                ).onSuccess {
-                    if (isExtend.not()) loadHomeData()
-                }.onFailure { throwable ->
-                    _errorFlow.emit(throwable)
                 }
             }
         }

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/HomeViewModel.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/HomeViewModel.kt
@@ -1,6 +1,5 @@
 package com.teamhy2.feature.home
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.teamhy2.feature.home.model.HomeUiState
@@ -77,7 +76,6 @@ class HomeViewModel
                     isDismissedFlow.collect { isDismissed ->
                         _homeUiState.update { currentState ->
                             if (currentState is HomeUiState.Success) {
-                                Log.d("bandal", "loadPromotionData: isDismissed = $isDismissed promotion = $promotion")
                                 currentState.copy(
                                     promotion = promotion,
                                     isPromotionDialog = !isDismissed && promotion.isActive,

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/HomeViewModel.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/HomeViewModel.kt
@@ -3,8 +3,6 @@ package com.teamhy2.feature.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.teamhy2.feature.home.model.HomeUiState
-import com.teamhy2.hongikyeolgong2.timer.model.TimerService
-import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerUiState
 import com.teamhy2.main.domain.model.WeeklyStudyDay
 import com.teamhy2.main.domain.model.WiseSaying
 import com.teamhy2.main.domain.repository.StudyDayRepository
@@ -20,7 +18,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -32,7 +29,6 @@ class HomeViewModel
     constructor(
         private val wiseSayingRepository: WiseSayingRepository,
         private val studyDayRepository: StudyDayRepository,
-        private val timerService: TimerService,
     ) : ViewModel() {
         private val _homeUiState = MutableStateFlow<HomeUiState>(HomeUiState.Loading)
         val homeUiState: StateFlow<HomeUiState> = _homeUiState.asStateFlow()
@@ -67,33 +63,6 @@ class HomeViewModel
             }
         }
 
-        fun startTimerService(
-            startDateTime: LocalDateTime,
-            duration: Duration,
-        ) {
-            timerService.startService(startDateTime, duration)
-        }
-
-        fun stopTimerService() {
-            timerService.stopService()
-        }
-
-        fun saveStudyDay(isExtend: Boolean) {
-            val currentState = _homeUiState.value
-            if (currentState is HomeUiState.Success) {
-                viewModelScope.launch {
-                    studyDayRepository.saveStudyDay(
-                        startDateTime = currentState.timerUiState.startDateTime,
-                        endDateTime = LocalDateTime.now(),
-                    ).onSuccess {
-                        if (!isExtend) loadHomeData()
-                    }.onFailure { throwable ->
-                        _errorFlow.emit(throwable)
-                    }
-                }
-            }
-        }
-
         fun increaseTodayStudyCount() {
             _homeUiState.update { currentState ->
                 when (currentState) {
@@ -117,61 +86,18 @@ class HomeViewModel
             }
         }
 
-        fun updateTimerStateFromTimerViewModel(timerState: TimerUiState) {
-            _homeUiState.update { currentState ->
-                when (currentState) {
-                    is HomeUiState.Success -> {
-                        currentState.copy(
-                            timerUiState = timerState,
-                        )
-                    }
-
-                    else -> currentState
-                }
-            }
-        }
-
-        fun updateTimePickerVisibility(isVisible: Boolean) {
-            _homeUiState.update { currentState ->
-                when (currentState) {
-                    is HomeUiState.Success -> currentState.copy(isTimePickerVisible = isVisible)
-                    else -> currentState
-                }
-            }
-        }
-
-        fun updateTimerRunning(isTimerRunning: Boolean) {
-            _homeUiState.update { currentState ->
-                when (currentState) {
-                    is HomeUiState.Success -> currentState.copy(isTimerRunning = isTimerRunning)
-                    else -> currentState
-                }
-            }
-        }
-
-        fun updateSelectedTime(selectedTime: LocalDateTime) {
-            _homeUiState.update { currentState ->
-                when (currentState) {
-                    is HomeUiState.Success -> currentState.copy(selectedTime = selectedTime)
-                    else -> currentState
-                }
-            }
-        }
-
-        fun updateStudyRoomExtendDialogVisibility(isVisible: Boolean) {
-            _homeUiState.update { currentState ->
-                when (currentState) {
-                    is HomeUiState.Success -> currentState.copy(isStudyRoomExtendDialog = isVisible)
-                    else -> currentState
-                }
-            }
-        }
-
-        fun updateStudyRoomEndDialogVisibility(isVisible: Boolean) {
-            _homeUiState.update { currentState ->
-                when (currentState) {
-                    is HomeUiState.Success -> currentState.copy(isStudyRoomEndDialog = isVisible)
-                    else -> currentState
+        fun saveStudyDay(
+            startDateTime: LocalDateTime,
+            isExtend: Boolean,
+        ) {
+            viewModelScope.launch {
+                studyDayRepository.saveStudyDay(
+                    startDateTime = startDateTime,
+                    endDateTime = LocalDateTime.now(),
+                ).onSuccess {
+                    if (isExtend.not()) loadHomeData()
+                }.onFailure { throwable ->
+                    _errorFlow.emit(throwable)
                 }
             }
         }

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/MainNotificationHandler.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/MainNotificationHandler.kt
@@ -5,6 +5,7 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.teamhy2.feature.main.MainActivity
 import com.teamhy2.feature.setting.domain.repository.SettingsRepository
@@ -57,6 +58,7 @@ class MainNotificationHandler
         }
 
         override fun buildServiceNotification(): Notification {
+            Log.d("bandal", "buildServiceNotification: 호출")
             return NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
                 .setContentTitle("홍익열공이 열공중")
                 .setContentText("지금 열람실을 이용중이에요!")
@@ -68,6 +70,8 @@ class MainNotificationHandler
         }
 
         override fun buildGeneralNotification(contentText: String): Notification {
+            Log.d("bandal", "buildGeneralNotification: 호출")
+
             return NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
                 .setContentTitle("홍익열공이 알림")
                 .setContentText(contentText)
@@ -79,6 +83,8 @@ class MainNotificationHandler
         }
 
         override fun showSimpleNotification(pushText: PushText) {
+            Log.d("bandal", "showSimpleNotification: $pushText")
+
             val notification = buildGeneralNotification(context.getString(pushText.id))
 
             if (notificationChannel.value) {

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/component/RunningTimerComponent.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/component/RunningTimerComponent.kt
@@ -18,15 +18,16 @@ import com.teamhy2.designsystem.ui.theme.Gray600
 import com.teamhy2.designsystem.ui.theme.HY2Theme
 import com.teamhy2.hongikyeolgong2.main.presentation.R
 import com.teamhy2.hongikyeolgong2.timer.presentation.HY2Timer
+import com.teamhy2.hongikyeolgong2.timer.presentation.model.LeftTime
+import com.teamhy2.hongikyeolgong2.timer.presentation.model.Meridiem
+import com.teamhy2.hongikyeolgong2.timer.presentation.model.Time
+import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerUiState
+import java.time.Duration
+import java.time.LocalDateTime
 
 @Composable
 fun RunningTimerComponent(
-    durationAsSecond: Long,
-    startTime: String,
-    endTime: String,
-    startTimeMeridiem: String,
-    endTimeMeridiem: String,
-    leftTime: String,
+    timerUiState: TimerUiState.Running,
     onStudyRoomExtendClick: () -> Unit,
     onStudyRoomEndClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -38,12 +39,12 @@ fun RunningTimerComponent(
         Spacer(modifier = Modifier.height(20.dp))
         Box {
             HY2Timer(
-                durationAsSecond = durationAsSecond,
-                leftTime = leftTime,
-                startTime = startTime,
-                endTime = endTime,
-                startTimeMeridiem = startTimeMeridiem,
-                endTimeMeridiem = endTimeMeridiem,
+                durationAsSecond = timerUiState.duration.seconds,
+                leftTime = timerUiState.leftTime.value,
+                startTime = timerUiState.startTime.hourAndMinute,
+                startTimeMeridiem = timerUiState.startTime.meridiem.label,
+                endTime = timerUiState.endTime.hourAndMinute,
+                endTimeMeridiem = timerUiState.endTime.meridiem.label,
             )
         }
         Spacer(
@@ -53,7 +54,7 @@ fun RunningTimerComponent(
                     .weight(1f),
         )
 
-        if (leftTime <= extendThreshold) {
+        if (timerUiState.leftTime.value <= extendThreshold) {
             HY2Button(
                 text = stringResource(R.string.main_extend_study_room),
                 onClick = onStudyRoomExtendClick,
@@ -75,14 +76,28 @@ fun RunningTimerComponent(
 @Preview(showBackground = true)
 @Composable
 fun TimerScreenPreview_LessThanExtendThreshold() {
+    val timerUiState =
+        TimerUiState.Running(
+            startDateTime = LocalDateTime.now(),
+            startTime =
+                Time(
+                    meridiem = Meridiem.AM,
+                    hour = "11",
+                    minute = "30",
+                ),
+            endTime =
+                Time(
+                    meridiem = Meridiem.PM,
+                    hour = "12",
+                    minute = "00",
+                ),
+            leftTime = LeftTime("00:14:03"),
+            duration = Duration.ofSeconds(14400L),
+        )
+
     HY2Theme {
         RunningTimerComponent(
-            durationAsSecond = 14400L,
-            startTime = "11:30",
-            endTime = "12:00",
-            startTimeMeridiem = "AM",
-            endTimeMeridiem = "PM",
-            leftTime = "00:14:03",
+            timerUiState = timerUiState,
             onStudyRoomExtendClick = { },
             onStudyRoomEndClick = { },
             modifier = Modifier.background(Black),
@@ -93,14 +108,28 @@ fun TimerScreenPreview_LessThanExtendThreshold() {
 @Preview(showBackground = true)
 @Composable
 fun TimerScreenPreview_MoreThanExtendThreshold() {
+    val timerUiState =
+        TimerUiState.Running(
+            startDateTime = LocalDateTime.now(),
+            startTime =
+                Time(
+                    meridiem = Meridiem.AM,
+                    hour = "11",
+                    minute = "30",
+                ),
+            endTime =
+                Time(
+                    meridiem = Meridiem.PM,
+                    hour = "12",
+                    minute = "00",
+                ),
+            leftTime = LeftTime("00:45:00"),
+            duration = Duration.ofSeconds(14400L),
+        )
+
     HY2Theme {
         RunningTimerComponent(
-            durationAsSecond = 14400L,
-            startTime = "11:30",
-            endTime = "12:00",
-            startTimeMeridiem = "AM",
-            endTimeMeridiem = "PM",
-            leftTime = "00:45:00",
+            timerUiState = timerUiState,
             onStudyRoomExtendClick = { },
             onStudyRoomEndClick = { },
             modifier = Modifier.background(Black),

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/component/RunningTimerComponent.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/component/RunningTimerComponent.kt
@@ -20,7 +20,7 @@ import com.teamhy2.hongikyeolgong2.main.presentation.R
 import com.teamhy2.hongikyeolgong2.timer.presentation.HY2Timer
 import com.teamhy2.hongikyeolgong2.timer.presentation.model.LeftTime
 import com.teamhy2.hongikyeolgong2.timer.presentation.model.Meridiem
-import com.teamhy2.hongikyeolgong2.timer.presentation.model.Time
+import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerTime
 import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerUiState
 import java.time.Duration
 import java.time.LocalDateTime
@@ -41,9 +41,9 @@ fun RunningTimerComponent(
             HY2Timer(
                 durationAsSecond = timerUiState.duration.seconds,
                 leftTime = timerUiState.leftTime.value,
-                startTime = timerUiState.startTime.hourAndMinute,
+                startTime = timerUiState.startTime.formattedTime,
                 startTimeMeridiem = timerUiState.startTime.meridiem.label,
-                endTime = timerUiState.endTime.hourAndMinute,
+                endTime = timerUiState.endTime.formattedTime,
                 endTimeMeridiem = timerUiState.endTime.meridiem.label,
             )
         }
@@ -80,13 +80,13 @@ fun TimerScreenPreview_LessThanExtendThreshold() {
         TimerUiState.Running(
             startDateTime = LocalDateTime.now(),
             startTime =
-                Time(
+                TimerTime(
                     meridiem = Meridiem.AM,
                     hour = "11",
                     minute = "30",
                 ),
             endTime =
-                Time(
+                TimerTime(
                     meridiem = Meridiem.PM,
                     hour = "12",
                     minute = "00",
@@ -112,13 +112,13 @@ fun TimerScreenPreview_MoreThanExtendThreshold() {
         TimerUiState.Running(
             startDateTime = LocalDateTime.now(),
             startTime =
-                Time(
+                TimerTime(
                     meridiem = Meridiem.AM,
                     hour = "11",
                     minute = "30",
                 ),
             endTime =
-                Time(
+                TimerTime(
                     meridiem = Meridiem.PM,
                     hour = "12",
                     minute = "00",

--- a/main-presentation/src/main/java/com/teamhy2/feature/home/model/HomeUiState.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/home/model/HomeUiState.kt
@@ -1,9 +1,7 @@
 package com.teamhy2.feature.home.model
 
-import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerUiState
 import com.teamhy2.main.domain.model.WeeklyStudyDay
 import com.teamhy2.main.domain.model.WiseSaying
-import java.time.LocalDateTime
 
 sealed interface HomeUiState {
     data object Loading : HomeUiState
@@ -11,12 +9,6 @@ sealed interface HomeUiState {
     data class Success(
         val wiseSaying: WiseSaying = WiseSaying.DEFAULT,
         val weeklyStudyDays: List<WeeklyStudyDay> = WeeklyStudyDay.defaultWeek(),
-        val isTimePickerVisible: Boolean = false,
-        val isStudyRoomExtendDialog: Boolean = false,
-        val isStudyRoomEndDialog: Boolean = false,
-        val selectedTime: LocalDateTime = LocalDateTime.now(),
-        val isTimerRunning: Boolean = false,
-        val timerUiState: TimerUiState = TimerUiState(),
     ) : HomeUiState
 
     data class Error(val message: String?) : HomeUiState

--- a/timer-data/build.gradle.kts
+++ b/timer-data/build.gradle.kts
@@ -9,4 +9,5 @@ android {
 dependencies {
     implementation(projects.timerDomain)
     implementation(projects.core.remote)
+    implementation(libs.datastore.preferences)
 }

--- a/timer-data/src/main/java/com/teamhy2/hongikyeolgong2/timer/data/datastore/TimerDataStoreDataSource.kt
+++ b/timer-data/src/main/java/com/teamhy2/hongikyeolgong2/timer/data/datastore/TimerDataStoreDataSource.kt
@@ -1,0 +1,69 @@
+package com.teamhy2.hongikyeolgong2.timer.data.datastore
+
+import android.util.Log
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.teamhy2.hongikyeolgong2.timer.model.TimerDataSource
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+class TimerDataStoreDataSource
+    @Inject
+    constructor(
+        private val dataStore: DataStore<Preferences>,
+    ) : TimerDataSource {
+        override suspend fun getStartTime(): LocalDateTime? {
+            val startTime: String =
+                dataStore.data.map { preferences ->
+                    preferences[startTimeKey]
+                }.firstOrNull() ?: return null
+            Log.d("bandal", "getStartTime: $startTime")
+            return startTime.toLocalDateTimeIso()
+        }
+
+        override suspend fun getEndTime(): LocalDateTime? {
+            val endTime: String =
+                dataStore.data.map { preferences ->
+                    preferences[endTimeKey]
+                }.firstOrNull() ?: return null
+            Log.d("bandal", "getEndTime: $endTime")
+
+            return endTime.toLocalDateTimeIso()
+        }
+
+        override suspend fun saveStartTime(startTime: String) {
+            dataStore.edit { preferences ->
+                preferences[startTimeKey] = startTime
+            }
+        }
+
+        override suspend fun saveEndTime(endTime: String) {
+            dataStore.edit { preferences ->
+                preferences[endTimeKey] = endTime
+            }
+        }
+
+        override suspend fun clearTimes() {
+            dataStore.edit { preferences ->
+                preferences.remove(startTimeKey)
+                preferences.remove(endTimeKey)
+            }
+        }
+
+        private fun String.toLocalDateTimeIso(): LocalDateTime {
+            return LocalDateTime.parse(this, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        }
+
+        companion object {
+            private const val START_TIME_KEY = "start_time"
+            private const val END_TIME_KEY = "end_time"
+
+            private val startTimeKey = stringPreferencesKey(START_TIME_KEY)
+            private val endTimeKey = stringPreferencesKey(END_TIME_KEY)
+        }
+    }

--- a/timer-data/src/main/java/com/teamhy2/hongikyeolgong2/timer/data/di/TimerModule.kt
+++ b/timer-data/src/main/java/com/teamhy2/hongikyeolgong2/timer/data/di/TimerModule.kt
@@ -1,6 +1,8 @@
 package com.teamhy2.hongikyeolgong2.timer.data.di
 
+import com.teamhy2.hongikyeolgong2.timer.data.datastore.TimerDataStoreDataSource
 import com.teamhy2.hongikyeolgong2.timer.data.repository.RemoteTimerRepository
+import com.teamhy2.hongikyeolgong2.timer.model.TimerDataSource
 import com.teamhy2.hongikyeolgong2.timer.model.TimerRepository
 import dagger.Binds
 import dagger.Module
@@ -14,4 +16,8 @@ abstract class TimerModule {
     @Binds
     @Singleton
     abstract fun bindTimerRepository(remoteTimerRepository: RemoteTimerRepository): TimerRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindTimerDataSource(timerDataStoreDataSource: TimerDataStoreDataSource): TimerDataSource
 }

--- a/timer-data/src/main/java/com/teamhy2/hongikyeolgong2/timer/data/repository/RemoteTimerRepository.kt
+++ b/timer-data/src/main/java/com/teamhy2/hongikyeolgong2/timer/data/repository/RemoteTimerRepository.kt
@@ -2,15 +2,45 @@ package com.teamhy2.hongikyeolgong2.timer.data.repository
 
 import com.benenfeldt.remote.api.LibraryService
 import com.benenfeldt.remote.mapper.toResult
+import com.teamhy2.hongikyeolgong2.timer.model.TimerDataSource
+import com.teamhy2.hongikyeolgong2.timer.model.TimerDuration
 import com.teamhy2.hongikyeolgong2.timer.model.TimerRepository
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 class RemoteTimerRepository
     @Inject
     constructor(
         private val libraryService: LibraryService,
+        private val timerDataSource: TimerDataSource,
     ) : TimerRepository {
-        override suspend fun getStudyRoomHourDuration(): Result<Int> {
-            return libraryService.getStudyRoomHourDuration().toResult { it.data.libraryHours }
+        override suspend fun getStudyRoomHourDuration(): Int {
+            val studyRoomHourDuration =
+                libraryService.getStudyRoomHourDuration()
+                    .toResult { it.data.libraryHours }
+                    .getOrDefault(TimerRepository.MINIMUM_STUDY_ROOM_HOUR_DURATION)
+
+            return studyRoomHourDuration
+        }
+
+        override suspend fun getCurrentTimerDuration(): TimerDuration? {
+            val startTime: LocalDateTime = timerDataSource.getStartTime() ?: return null
+            val endTime: LocalDateTime = timerDataSource.getEndTime() ?: return null
+
+            if (endTime.isBefore(LocalDateTime.now())) {
+                timerDataSource.clearTimes()
+                return null
+            }
+
+            return TimerDuration(startTime, endTime)
+        }
+
+        override suspend fun setCurrentTimerDuration(timerDuration: TimerDuration) {
+            timerDataSource.saveStartTime(timerDuration.startTime.toString())
+            timerDataSource.saveEndTime(timerDuration.endTime.toString())
+        }
+
+        override suspend fun clearCurrentTimerDuration() {
+            timerDataSource.clearTimes()
         }
     }

--- a/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/Timer.kt
+++ b/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/Timer.kt
@@ -8,13 +8,21 @@ import java.time.LocalDateTime
 
 class Timer(
     val startTime: LocalDateTime,
-    duration: Duration,
+    private val duration: Duration,
 ) {
     var endTime: LocalDateTime = startTime.plusSeconds(duration.seconds)
         private set
 
     private val leftTime: Duration
         get() = calculateLeftTime()
+
+    constructor(
+        startTime: LocalDateTime,
+        duration: Duration,
+        endTime: LocalDateTime,
+    ) : this(startTime, duration) {
+        this.endTime = endTime
+    }
 
     fun emitTimerEvents(): Flow<Long> =
         flow {
@@ -35,6 +43,10 @@ class Timer(
             return Duration.ZERO
         }
         return Duration.between(now, endTime)
+    }
+
+    fun extend() {
+        endTime = endTime.plus(duration)
     }
 
     companion object {

--- a/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/Timer.kt
+++ b/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/Timer.kt
@@ -6,10 +6,11 @@ import kotlinx.coroutines.flow.flow
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 class Timer(
     private val startTime: LocalDateTime,
-    private val duration: Duration,
+    duration: Duration,
     private val events: Map<Long, () -> Unit>,
 ) {
     var endTime: LocalDateTime = startTime.plusSeconds(duration.seconds)
@@ -26,6 +27,7 @@ class Timer(
     val formattedLeftTime: String
         get() =
             String.format(
+                Locale.KOREA,
                 LEFT_TIME_FORMAT,
                 leftTime.toHours(),
                 leftTime.toMinutes() % 60,
@@ -49,11 +51,11 @@ class Timer(
 
     fun emitTimerEvents(): Flow<Long> =
         flow {
-            while (!isTimeOver()) {
+            while (isTimeOver().not()) {
                 val leftSeconds: Long = leftTime.seconds
                 events[leftSeconds]?.invoke()
                 emit(leftSeconds)
-                delay(DELAY_MILLIS)
+                delay(ONE_SECOND)
             }
         }
 
@@ -73,9 +75,16 @@ class Timer(
         private const val START_END_TIME_FORMAT: String = "hh:mm"
         private const val LEFT_TIME_FORMAT: String = "%02d:%02d:%02d"
         const val TIME_OVER: Long = 0L
-        private const val DELAY_MILLIS: Long = 1000L
+        private const val ONE_SECOND: Long = 1000L
 
         private val EVENT_TIMES: List<Long> =
             listOf(TIME_OVER)
+
+        val IDLE: Timer =
+            Timer(
+                startTime = LocalDateTime.MAX,
+                duration = Duration.ZERO,
+                events = mapOf(TIME_OVER to {}),
+            )
     }
 }

--- a/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/Timer.kt
+++ b/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/Timer.kt
@@ -9,16 +9,9 @@ import java.time.LocalDateTime
 class Timer(
     val startTime: LocalDateTime,
     duration: Duration,
-    private val events: Map<Long, () -> Unit>,
 ) {
     var endTime: LocalDateTime = startTime.plusSeconds(duration.seconds)
         private set
-
-    init {
-        require(events.keys.containsAll(EVENT_TIMES)) {
-            "포함되지 않은 시간이 있습니다."
-        }
-    }
 
     private val leftTime: Duration
         get() = calculateLeftTime()
@@ -27,7 +20,6 @@ class Timer(
         flow {
             while (isTimeOver().not()) {
                 val leftSeconds: Long = leftTime.seconds
-                events[leftSeconds]?.invoke()
                 emit(leftSeconds)
                 delay(ONE_SECOND)
             }
@@ -46,16 +38,12 @@ class Timer(
     }
 
     companion object {
-        const val TIME_OVER: Long = 0L
         private const val ONE_SECOND: Long = 1000L
-
-        private val EVENT_TIMES: List<Long> = listOf(TIME_OVER)
 
         val IDLE: Timer =
             Timer(
                 startTime = LocalDateTime.MAX,
                 duration = Duration.ZERO,
-                events = mapOf(TIME_OVER to {}),
             )
     }
 }

--- a/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/Timer.kt
+++ b/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/Timer.kt
@@ -26,15 +26,15 @@ class Timer(
 
     fun emitTimerEvents(): Flow<Long> =
         flow {
-            while (isTimeOver().not()) {
+            while (isNotTimeOver()) {
                 val leftSeconds: Long = leftTime.seconds
                 emit(leftSeconds)
                 delay(ONE_SECOND)
             }
         }
 
-    private fun isTimeOver(): Boolean {
-        return leftTime <= Duration.ZERO
+    private fun isNotTimeOver(): Boolean {
+        return leftTime > Duration.ZERO
     }
 
     private fun calculateLeftTime(): Duration {

--- a/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/Timer.kt
+++ b/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/Timer.kt
@@ -5,46 +5,20 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import java.time.Duration
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-import java.util.Locale
 
 class Timer(
-    private val startTime: LocalDateTime,
+    val startTime: LocalDateTime,
     duration: Duration,
     private val events: Map<Long, () -> Unit>,
 ) {
     var endTime: LocalDateTime = startTime.plusSeconds(duration.seconds)
         private set
-    private val timeFormatter: DateTimeFormatter =
-        DateTimeFormatter.ofPattern(START_END_TIME_FORMAT)
 
     init {
         require(events.keys.containsAll(EVENT_TIMES)) {
             "포함되지 않은 시간이 있습니다."
         }
     }
-
-    val formattedLeftTime: String
-        get() =
-            String.format(
-                Locale.KOREA,
-                LEFT_TIME_FORMAT,
-                leftTime.toHours(),
-                leftTime.toMinutes() % 60,
-                leftTime.seconds % 60,
-            )
-
-    val formattedStartTime: String
-        get() = startTime.format(timeFormatter)
-
-    val formattedEndTime: String
-        get() = endTime.format(timeFormatter)
-
-    val formattedStartTimeMeridiem: String
-        get() = if (startTime.hour >= 12) "PM" else "AM"
-
-    val formattedEndTimeMeridiem: String
-        get() = if (endTime.hour >= 12) "PM" else "AM"
 
     private val leftTime: Duration
         get() = calculateLeftTime()
@@ -72,13 +46,10 @@ class Timer(
     }
 
     companion object {
-        private const val START_END_TIME_FORMAT: String = "hh:mm"
-        private const val LEFT_TIME_FORMAT: String = "%02d:%02d:%02d"
         const val TIME_OVER: Long = 0L
         private const val ONE_SECOND: Long = 1000L
 
-        private val EVENT_TIMES: List<Long> =
-            listOf(TIME_OVER)
+        private val EVENT_TIMES: List<Long> = listOf(TIME_OVER)
 
         val IDLE: Timer =
             Timer(

--- a/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/TimerDataSource.kt
+++ b/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/TimerDataSource.kt
@@ -1,0 +1,15 @@
+package com.teamhy2.hongikyeolgong2.timer.model
+
+import java.time.LocalDateTime
+
+interface TimerDataSource {
+    suspend fun getStartTime(): LocalDateTime?
+
+    suspend fun getEndTime(): LocalDateTime?
+
+    suspend fun saveStartTime(startTime: String)
+
+    suspend fun saveEndTime(endTime: String)
+
+    suspend fun clearTimes()
+}

--- a/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/TimerDuration.kt
+++ b/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/TimerDuration.kt
@@ -1,0 +1,8 @@
+package com.teamhy2.hongikyeolgong2.timer.model
+
+import java.time.LocalDateTime
+
+data class TimerDuration(
+    val startTime: LocalDateTime,
+    val endTime: LocalDateTime,
+)

--- a/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/TimerRepository.kt
+++ b/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/TimerRepository.kt
@@ -1,5 +1,15 @@
 package com.teamhy2.hongikyeolgong2.timer.model
 
 interface TimerRepository {
-    suspend fun getStudyRoomHourDuration(): Result<Int>
+    suspend fun getStudyRoomHourDuration(): Int
+
+    suspend fun getCurrentTimerDuration(): TimerDuration?
+
+    suspend fun setCurrentTimerDuration(timerDuration: TimerDuration)
+
+    suspend fun clearCurrentTimerDuration()
+
+    companion object {
+        const val MINIMUM_STUDY_ROOM_HOUR_DURATION = 4
+    }
 }

--- a/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/TimerService.kt
+++ b/timer-domain/src/main/java/com/teamhy2/hongikyeolgong2/timer/model/TimerService.kt
@@ -1,12 +1,11 @@
 package com.teamhy2.hongikyeolgong2.timer.model
 
-import java.time.Duration
 import java.time.LocalDateTime
 
 interface TimerService {
     fun startService(
         startDateTime: LocalDateTime,
-        duration: Duration,
+        endDateTime: LocalDateTime,
     )
 
     fun stopService()

--- a/timer-presentation/build.gradle.kts
+++ b/timer-presentation/build.gradle.kts
@@ -8,5 +8,6 @@ android {
 
 dependencies {
     implementation(projects.timerDomain)
+    implementation(projects.mainDomain)
     implementation(projects.core.notification)
 }

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerForegroundService.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerForegroundService.kt
@@ -71,7 +71,7 @@ class TimerForegroundService
                 TIMER_NOTIFICATION_ID,
                 notificationHandler.buildServiceNotification(),
             )
-            startTimer(endTime) // TODO: 이게 문제임
+            startTimer(endTime)
 
             return START_NOT_STICKY
         }
@@ -84,19 +84,16 @@ class TimerForegroundService
         private fun startTimer(endTime: LocalDateTime) {
             timerJob?.cancel()
 
-            hasNotified30Min = false
-            hasNotified10Min = false
-
             timerJob =
                 serviceScope.launch {
                     while (true) {
-                        val remainingTime: Long =
+                        val leftTime =
                             endTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli() -
                                 LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
-                        Log.d("bandal", "remainingTime: $remainingTime")
 
-                        if (remainingTime <= 0 && hasNotified0Min.not()) {
-                            Log.d("bandal", "hasNotified0Min: $hasNotified0Min")
+                        Log.d("bandal", "remainingTime: $leftTime")
+
+                        if (leftTime <= 0 && hasNotified0Min.not()) {
                             notificationHandler.showSimpleNotification(PushText.ZERO_MINUTES)
                             hasNotified0Min = true
                             stopSelf()
@@ -104,15 +101,13 @@ class TimerForegroundService
                         }
 
                         when {
-                            remainingTime <= 600000 && hasNotified10Min.not() -> {
-                                Log.d("bandal", "hasNotified10Min: $hasNotified10Min")
+                            leftTime <= 600000 && hasNotified10Min.not() -> {
                                 notificationHandler.showSimpleNotification(PushText.TEN_MINUTES)
                                 hasNotified10Min = true
                                 continue
                             }
 
-                            remainingTime <= 1800000 && hasNotified30Min.not() -> {
-                                Log.d("bandal", "hasNotified30Min: $hasNotified30Min")
+                            leftTime <= 1800000 && hasNotified30Min.not() -> {
                                 notificationHandler.showSimpleNotification(PushText.THIRTY_MINUTES)
                                 hasNotified30Min = true
                                 continue

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerForegroundService.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerForegroundService.kt
@@ -15,7 +15,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import java.time.Instant.ofEpochMilli
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -37,6 +41,8 @@ class TimerForegroundService
 
         private val serviceScope: CoroutineScope = CoroutineScope(Dispatchers.Main)
         private var timerJob: Job? = null
+
+        private val startTimeState = MutableStateFlow(LocalDateTime.now())
 
         private var hasNotified30Min: Boolean = false
         private var hasNotified10Min: Boolean = false
@@ -139,6 +145,8 @@ class TimerForegroundService
         ) {
             val appContext: Context = context.applicationContext
 
+            startTimeState.update { startDateTime }
+
             val startTimeMillis: Long =
                 startDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
             val endTimeMillis: Long =
@@ -155,6 +163,14 @@ class TimerForegroundService
 
         override fun stopService() {
             val stopIntent = Intent(context, TimerForegroundService::class.java)
+            runBlocking {
+                withTimeout(4000L) {
+                    studyDayRepository.saveStudyDay(startDateTime = startTimeState.value, endDateTime = LocalDateTime.now())
+                }.onFailure {
+                    Log.d("bandal", "stopService: ${it.message}")
+                }
+            }
+            Log.d("bandal", "onDestroy: called ${startTimeState.value} and now ${LocalDateTime.now()}")
             context.stopService(stopIntent)
         }
 

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerForegroundService.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerForegroundService.kt
@@ -60,7 +60,7 @@ class TimerForegroundService
             val startTimeMillis: Long =
                 intent.getLongExtra(EXTRA_START_TIME, System.currentTimeMillis())
             val endTimeMillis: Long =
-                intent.getLongExtra(EXTRA_END_TIME, System.currentTimeMillis() + 1000 * 60 * 60 * 4)
+                intent.getLongExtra(EXTRA_END_TIME, System.currentTimeMillis() + FOUR_HOUR_MILLIS)
 
             val startTime: LocalDateTime =
                 LocalDateTime.ofInstant(
@@ -74,8 +74,7 @@ class TimerForegroundService
                     ZoneId.systemDefault(),
                 )
 
-            Log.d("bandal", "startTime: $startTime")
-            Log.d("bandal", "endTime: $endTime")
+            Log.i("TimerForegroundService", "startTime: $startTime / endTime: $endTime")
 
             startForeground(
                 TIMER_NOTIFICATION_ID,
@@ -103,11 +102,11 @@ class TimerForegroundService
             timerJob =
                 serviceScope.launch {
                     while (true) {
-                        val leftTime =
+                        val leftTime: Long =
                             endTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli() -
                                 LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
 
-                        Log.d("bandal", "remainingTime: $leftTime")
+                        Log.i("TimerForegroundService", "remainingTimeMillis: $leftTime")
 
                         if (leftTime <= 0 && hasNotified0Min.not()) {
                             studyDayRepository.saveStudyDay(
@@ -164,17 +163,18 @@ class TimerForegroundService
         override fun stopService() {
             val stopIntent = Intent(context, TimerForegroundService::class.java)
             runBlocking {
-                withTimeout(4000L) {
+                withTimeout(ANR_TIMEOUT) {
                     studyDayRepository.saveStudyDay(startDateTime = startTimeState.value, endDateTime = LocalDateTime.now())
                 }.onFailure {
-                    Log.d("bandal", "stopService: ${it.message}")
+                    Log.d("TimerForegroundService", "stopService: ${it.message}")
                 }
             }
-            Log.d("bandal", "onDestroy: called ${startTimeState.value} and now ${LocalDateTime.now()}")
             context.stopService(stopIntent)
         }
 
         companion object {
+            private const val FOUR_HOUR_MILLIS = 1000 * 60 * 60 * 4
+            private const val ANR_TIMEOUT = 4000L
             const val TIMER_NOTIFICATION_ID: Int = 1
             const val EXTRA_START_TIME: String = "extra_start_time"
             const val EXTRA_END_TIME: String = "extra_end_time"

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerForegroundService.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerForegroundService.kt
@@ -4,6 +4,7 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.os.IBinder
+import android.util.Log
 import com.teamhy2.hongikyeolgong2.notification.NotificationHandler
 import com.teamhy2.hongikyeolgong2.notification.PushText
 import com.teamhy2.hongikyeolgong2.timer.model.TimerService
@@ -14,10 +15,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import java.time.Duration
+import java.time.Instant.ofEpochMilli
 import java.time.LocalDateTime
 import java.time.ZoneId
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -33,7 +33,6 @@ class TimerForegroundService
 
         private val serviceScope: CoroutineScope = CoroutineScope(Dispatchers.Main)
         private var timerJob: Job? = null
-        private var endTime: Long = 0L
 
         private var hasNotified30Min: Boolean = false
         private var hasNotified10Min: Boolean = false
@@ -46,23 +45,33 @@ class TimerForegroundService
             flags: Int,
             startId: Int,
         ): Int {
+            if (intent == null) return START_STICKY
+
             val startTimeMillis: Long =
-                intent?.getLongExtra(EXTRA_START_TIME, System.currentTimeMillis())
-                    ?: System.currentTimeMillis()
-            val durationMillis: Long = intent?.getLongExtra(EXTRA_TIME, 0L) ?: 0L
+                intent.getLongExtra(EXTRA_START_TIME, System.currentTimeMillis())
+            val endTimeMillis: Long =
+                intent.getLongExtra(EXTRA_END_TIME, System.currentTimeMillis() + 1000 * 60 * 60 * 4)
 
             val startTime: LocalDateTime =
                 LocalDateTime.ofInstant(
-                    java.time.Instant.ofEpochMilli(startTimeMillis),
+                    ofEpochMilli(startTimeMillis),
                     ZoneId.systemDefault(),
                 )
-            val duration: Duration = Duration.ofMillis(durationMillis)
+
+            val endTime: LocalDateTime =
+                LocalDateTime.ofInstant(
+                    ofEpochMilli(endTimeMillis),
+                    ZoneId.systemDefault(),
+                )
+
+            Log.d("bandal", "startTime: $startTime")
+            Log.d("bandal", "endTime: $endTime")
 
             startForeground(
                 TIMER_NOTIFICATION_ID,
                 notificationHandler.buildServiceNotification(),
             )
-            startTimer(startTime, duration)
+            startTimer(endTime) // TODO: 이게 문제임
 
             return START_NOT_STICKY
         }
@@ -72,15 +81,8 @@ class TimerForegroundService
             super.onDestroy()
         }
 
-        private fun startTimer(
-            startTime: LocalDateTime,
-            duration: Duration,
-        ) {
+        private fun startTimer(endTime: LocalDateTime) {
             timerJob?.cancel()
-
-            val startTimeInMillis: Long =
-                startTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
-            endTime = startTimeInMillis + duration.toMillis()
 
             hasNotified30Min = false
             hasNotified10Min = false
@@ -88,9 +90,13 @@ class TimerForegroundService
             timerJob =
                 serviceScope.launch {
                     while (true) {
-                        val remainingTime: Long = endTime - System.currentTimeMillis()
+                        val remainingTime: Long =
+                            endTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli() -
+                                LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+                        Log.d("bandal", "remainingTime: $remainingTime")
 
                         if (remainingTime <= 0 && hasNotified0Min.not()) {
+                            Log.d("bandal", "hasNotified0Min: $hasNotified0Min")
                             notificationHandler.showSimpleNotification(PushText.ZERO_MINUTES)
                             hasNotified0Min = true
                             stopSelf()
@@ -98,13 +104,15 @@ class TimerForegroundService
                         }
 
                         when {
-                            remainingTime <= TimeUnit.MINUTES.toMillis(10L) && hasNotified10Min.not() -> {
+                            remainingTime <= 600000 && hasNotified10Min.not() -> {
+                                Log.d("bandal", "hasNotified10Min: $hasNotified10Min")
                                 notificationHandler.showSimpleNotification(PushText.TEN_MINUTES)
                                 hasNotified10Min = true
                                 continue
                             }
 
-                            remainingTime <= TimeUnit.MINUTES.toMillis(30L) && hasNotified30Min.not() -> {
+                            remainingTime <= 1800000 && hasNotified30Min.not() -> {
+                                Log.d("bandal", "hasNotified30Min: $hasNotified30Min")
                                 notificationHandler.showSimpleNotification(PushText.THIRTY_MINUTES)
                                 hasNotified30Min = true
                                 continue
@@ -118,17 +126,21 @@ class TimerForegroundService
 
         override fun startService(
             startDateTime: LocalDateTime,
-            duration: Duration,
+            endDateTime: LocalDateTime,
         ) {
             val appContext: Context = context.applicationContext
+
             val startTimeMillis: Long =
                 startDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+            val endTimeMillis: Long =
+                endDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
 
             val startIntent: Intent =
                 Intent(appContext, TimerForegroundService::class.java).apply {
                     putExtra(EXTRA_START_TIME, startTimeMillis)
-                    putExtra(EXTRA_TIME, duration.toMillis())
+                    putExtra(EXTRA_END_TIME, endTimeMillis)
                 }
+
             appContext.startForegroundService(startIntent)
         }
 
@@ -139,7 +151,7 @@ class TimerForegroundService
 
         companion object {
             const val TIMER_NOTIFICATION_ID: Int = 1
-            const val EXTRA_TIME: String = "extra_time"
             const val EXTRA_START_TIME: String = "extra_start_time"
+            const val EXTRA_END_TIME: String = "extra_end_time"
         }
     }

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerForegroundService.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerForegroundService.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import com.teamhy2.hongikyeolgong2.notification.NotificationHandler
 import com.teamhy2.hongikyeolgong2.notification.PushText
 import com.teamhy2.hongikyeolgong2.timer.model.TimerService
+import com.teamhy2.main.domain.repository.StudyDayRepository
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
@@ -30,6 +31,9 @@ class TimerForegroundService
         @Inject
         @ApplicationContext
         lateinit var context: Context
+
+        @Inject
+        lateinit var studyDayRepository: StudyDayRepository
 
         private val serviceScope: CoroutineScope = CoroutineScope(Dispatchers.Main)
         private var timerJob: Job? = null
@@ -71,7 +75,10 @@ class TimerForegroundService
                 TIMER_NOTIFICATION_ID,
                 notificationHandler.buildServiceNotification(),
             )
-            startTimer(endTime)
+            startTimer(
+                startTime = startTime,
+                endTime = endTime,
+            )
 
             return START_NOT_STICKY
         }
@@ -81,7 +88,10 @@ class TimerForegroundService
             super.onDestroy()
         }
 
-        private fun startTimer(endTime: LocalDateTime) {
+        private fun startTimer(
+            startTime: LocalDateTime,
+            endTime: LocalDateTime,
+        ) {
             timerJob?.cancel()
 
             timerJob =
@@ -94,6 +104,10 @@ class TimerForegroundService
                         Log.d("bandal", "remainingTime: $leftTime")
 
                         if (leftTime <= 0 && hasNotified0Min.not()) {
+                            studyDayRepository.saveStudyDay(
+                                startDateTime = startTime,
+                                endDateTime = endTime,
+                            )
                             notificationHandler.showSimpleNotification(PushText.ZERO_MINUTES)
                             hasNotified0Min = true
                             stopSelf()

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
@@ -7,17 +7,21 @@ import com.teamhy2.hongikyeolgong2.timer.model.Timer
 import com.teamhy2.hongikyeolgong2.timer.model.TimerDuration
 import com.teamhy2.hongikyeolgong2.timer.model.TimerRepository
 import com.teamhy2.hongikyeolgong2.timer.model.TimerService
+import com.teamhy2.hongikyeolgong2.timer.presentation.model.LeftTime
+import com.teamhy2.hongikyeolgong2.timer.presentation.model.Time
 import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.Duration
@@ -34,67 +38,82 @@ class TimerViewModel
         private var timer: Timer = Timer.IDLE
         private var timerJob: Job? = null
 
-        private val _timerState = MutableStateFlow(TimerUiState())
+        private val _timerState: MutableStateFlow<TimerUiState> = MutableStateFlow(TimerUiState.Idle)
         val timerState: StateFlow<TimerUiState> = _timerState.asStateFlow()
 
         private val _errorFlow = MutableSharedFlow<Throwable>()
         val errorFlow: SharedFlow<Throwable> = _errorFlow.asSharedFlow()
 
+        private val studyRoomDuration: StateFlow<Int> =
+            flow { emit(timerRepository.getStudyRoomHourDuration()) }
+                .catch { throwable ->
+                    _errorFlow.emit(throwable)
+                }
+                .stateIn(
+                    scope = viewModelScope,
+                    started = SharingStarted.WhileSubscribed(5000),
+                    initialValue = 1,
+                )
+
         init {
-            initTimer()
+//            initTimer()
         }
 
         private fun initTimer() {
-            viewModelScope.launch {
-                val studyRoomDurationDeferred: Deferred<Long> =
-                    async { timerRepository.getStudyRoomHourDuration().toLong() }
-                val timerDurationDeferred: Deferred<TimerDuration?> =
-                    async { timerRepository.getCurrentTimerDuration() }
-
-                // FIXME: val studyRoomDuration: Long = studyRoomDurationDeferred.await()
-                val studyRoomDuration: Long = 1L
-                val timerDuration: TimerDuration? = timerDurationDeferred.await()
-
-                Log.d("bandal", "studyRoomDuration: $studyRoomDuration")
-                Log.d("bandal", "timerDuration: $timerDuration")
-
-                _timerState.update { state ->
-                    state.copy(duration = Duration.ofHours(studyRoomDuration))
-                }
-
-                if (timerDuration == null) {
-                    timerRepository.clearCurrentTimerDuration()
-                    return@launch
-                }
+//            viewModelScope.launch {
+//                val timerDurationDeferred: Deferred<TimerDuration?> =
+//                    async { timerRepository.getCurrentTimerDuration() }
+//
+//                // FIXME: val studyRoomDuration: Long = studyRoomDurationDeferred.await()
+//                val studyRoomDuration: Long = 1L
+//                val timerDuration: TimerDuration? = timerDurationDeferred.await()
+//
+//                Log.d("bandal", "studyRoomDuration: $studyRoomDuration")
+//                Log.d("bandal", "timerDuration: $timerDuration")
+//
+//                _timerState.update { state ->
+//                    when
+//                    state.copy(duration = Duration.ofHours(studyRoomDuration))
+//                }
+//
+//                if (timerDuration == null) {
+//                    timerRepository.clearCurrentTimerDuration()
+//                    return@launch
+//                }
 
 //                setTimer(
 //                    startDateTime = timerDuration.startTime,
 //                    duration = Duration.ofHours(studyRoomDuration),
 //                    events = mapOf(Timer.TIME_OVER to {}),
 //                )
-            }
+//            }
         }
 
         fun setTimer(
             startDateTime: LocalDateTime,
-            duration: Duration = timerState.value.duration,
             events: Map<Long, () -> Unit>,
         ) {
             Log.d("bandal", "setTimer: 호출")
+
+            val duration = Duration.ofHours(studyRoomDuration.value.toLong())
             timer = Timer(startDateTime, duration, events)
             timerJob?.cancel()
-            _timerState.value =
-                TimerUiState(
+            val startTime = Time.create(timer.startTime)
+            val endTime = Time.create(timer.endTime)
+            val leftTime = LeftTime.create(timer.endTime)
+
+            _timerState.update {
+                TimerUiState.Running(
                     startDateTime = startDateTime,
-                    startTime = timer.formattedStartTime,
-                    startTimeMeridiem = timer.formattedStartTimeMeridiem,
-                    endTime = timer.formattedEndTime,
-                    endTimeMeridiem = timer.formattedEndTimeMeridiem,
-                    leftTime = timer.formattedLeftTime,
+                    startTime = startTime,
+                    endTime = endTime,
+                    leftTime = leftTime,
                     duration = duration,
-                    isRunning = true,
                 )
+            }
+
             startTimer()
+
             timerService.startService(startDateTime, startDateTime.plus(duration))
 
             viewModelScope.launch {
@@ -124,19 +143,22 @@ class TimerViewModel
             timerJob =
                 viewModelScope.launch {
                     timer.emitTimerEvents().collect { timeLeft ->
-                        _timerState.update {
-                            _timerState.value.copy(
-                                leftTime = timer.formattedLeftTime,
-                            )
+                        _timerState.update { state ->
+                            when (state) {
+                                is TimerUiState.Idle -> state
+                                is TimerUiState.Running -> {
+                                    state.copy(
+                                        leftTime = LeftTime.create(timer.endTime),
+                                    )
+                                }
+                            }
                         }
                         if (timeLeft <= 0) {
                             timer = Timer.IDLE
                             timerJob?.cancel()
                             timerJob = null
-                            _timerState.update { state ->
-                                state.copy(
-                                    isRunning = false,
-                                )
+                            _timerState.update {
+                                TimerUiState.Idle
                             }
                             timerRepository.clearCurrentTimerDuration()
                         }
@@ -150,7 +172,7 @@ class TimerViewModel
             timerJob = null
             timer = Timer.IDLE
             _timerState.update {
-                it.copy(isRunning = false)
+                TimerUiState.Idle
             }
             viewModelScope.launch {
                 timerRepository.clearCurrentTimerDuration()

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
@@ -180,7 +180,7 @@ class TimerViewModel
                 )
             }
 
-            val startTime = LocalDateTime.now()
+            val startTime: LocalDateTime = LocalDateTime.now()
 
             viewModelScope.launch {
                 timerRepository.clearCurrentTimerDuration()

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
@@ -1,18 +1,24 @@
 package com.teamhy2.hongikyeolgong2.timer.presentation
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.teamhy2.hongikyeolgong2.timer.model.Timer
+import com.teamhy2.hongikyeolgong2.timer.model.TimerDuration
 import com.teamhy2.hongikyeolgong2.timer.model.TimerRepository
+import com.teamhy2.hongikyeolgong2.timer.model.TimerService
 import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.Duration
 import java.time.LocalDateTime
@@ -23,42 +29,60 @@ class TimerViewModel
     @Inject
     constructor(
         private val timerRepository: TimerRepository,
+        private val timerService: TimerService,
     ) : ViewModel() {
-        private lateinit var timer: Timer
+        private var timer: Timer = Timer.IDLE
         private var timerJob: Job? = null
 
         private val _timerState = MutableStateFlow(TimerUiState())
         val timerState: StateFlow<TimerUiState> = _timerState.asStateFlow()
 
-        private val _durationHour: MutableStateFlow<Duration> = MutableStateFlow(Duration.ZERO)
-        val durationHour: StateFlow<Duration> = _durationHour.asStateFlow()
-
         private val _errorFlow = MutableSharedFlow<Throwable>()
         val errorFlow: SharedFlow<Throwable> = _errorFlow.asSharedFlow()
 
         init {
-            getStudyRoomDuration()
+            initTimer()
         }
 
-        private fun getStudyRoomDuration() {
+        private fun initTimer() {
             viewModelScope.launch {
-                timerRepository.getStudyRoomHourDuration()
-                    .onSuccess { studyRoomHourDuration ->
-                        _durationHour.value = Duration.ofHours(studyRoomHourDuration.toLong())
-                    }
-                    .onFailure { throwable ->
-                        _errorFlow.emit(throwable)
-                    }
+                val studyRoomDurationDeferred: Deferred<Long> =
+                    async { timerRepository.getStudyRoomHourDuration().toLong() }
+                val timerDurationDeferred: Deferred<TimerDuration?> =
+                    async { timerRepository.getCurrentTimerDuration() }
+
+                // FIXME: val studyRoomDuration: Long = studyRoomDurationDeferred.await()
+                val studyRoomDuration: Long = 1L
+                val timerDuration: TimerDuration? = timerDurationDeferred.await()
+
+                Log.d("bandal", "studyRoomDuration: $studyRoomDuration")
+                Log.d("bandal", "timerDuration: $timerDuration")
+
+                _timerState.update { state ->
+                    state.copy(duration = Duration.ofHours(studyRoomDuration))
+                }
+
+                if (timerDuration == null) {
+                    timerRepository.clearCurrentTimerDuration()
+                    return@launch
+                }
+
+//                setTimer(
+//                    startDateTime = timerDuration.startTime,
+//                    duration = Duration.ofHours(studyRoomDuration),
+//                    events = mapOf(Timer.TIME_OVER to {}),
+//                )
             }
         }
 
         fun setTimer(
             startDateTime: LocalDateTime,
-            duration: Duration = durationHour.value,
+            duration: Duration = timerState.value.duration,
             events: Map<Long, () -> Unit>,
         ) {
-            timerJob?.cancel()
+            Log.d("bandal", "setTimer: 호출")
             timer = Timer(startDateTime, duration, events)
+            timerJob?.cancel()
             _timerState.value =
                 TimerUiState(
                     startDateTime = startDateTime,
@@ -67,23 +91,69 @@ class TimerViewModel
                     endTime = timer.formattedEndTime,
                     endTimeMeridiem = timer.formattedEndTimeMeridiem,
                     leftTime = timer.formattedLeftTime,
+                    duration = duration,
                     isRunning = true,
                 )
             startTimer()
+            timerService.startService(startDateTime, startDateTime.plus(duration))
+
+            viewModelScope.launch {
+                if (timerRepository.getCurrentTimerDuration() == null) {
+                    saveCurrentTimerDuration(startDateTime, duration)
+                }
+            }
+        }
+
+        private fun saveCurrentTimerDuration(
+            startTime: LocalDateTime,
+            duration: Duration,
+        ) {
+            viewModelScope.launch {
+                timerRepository.setCurrentTimerDuration(
+                    TimerDuration(
+                        startTime = startTime,
+                        endTime = startTime.plus(duration),
+                    ),
+                )
+            }
         }
 
         private fun startTimer() {
+            if (timer == Timer.IDLE) return
+
             timerJob =
                 viewModelScope.launch {
                     timer.emitTimerEvents().collect { timeLeft ->
-                        _timerState.value =
+                        _timerState.update {
                             _timerState.value.copy(
                                 leftTime = timer.formattedLeftTime,
                             )
+                        }
                         if (timeLeft <= 0) {
+                            timer = Timer.IDLE
                             timerJob?.cancel()
+                            timerJob = null
+                            _timerState.update { state ->
+                                state.copy(
+                                    isRunning = false,
+                                )
+                            }
+                            timerRepository.clearCurrentTimerDuration()
                         }
                     }
                 }
+        }
+
+        fun stopTimer() {
+            timerService.stopService()
+            timerJob?.cancel()
+            timerJob = null
+            timer = Timer.IDLE
+            _timerState.update {
+                it.copy(isRunning = false)
+            }
+            viewModelScope.launch {
+                timerRepository.clearCurrentTimerDuration()
+            }
         }
     }

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
@@ -1,5 +1,6 @@
 package com.teamhy2.hongikyeolgong2.timer.presentation
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.teamhy2.hongikyeolgong2.timer.model.Timer
@@ -46,48 +47,38 @@ class TimerViewModel
                 studyRoomDuration.value = 1
                 // FIXME: studyRoomDuration.value = timerRepository.getStudyRoomHourDuration()
             }
+            initTimer()
         }
 
         private fun initTimer() {
-//            viewModelScope.launch {
-//                val timerDurationDeferred: Deferred<TimerDuration?> =
-//                    async { timerRepository.getCurrentTimerDuration() }
-//
-//                // FIXME: val studyRoomDuration: Long = studyRoomDurationDeferred.await()
-//                val studyRoomDuration: Long = 1L
-//                val timerDuration: TimerDuration? = timerDurationDeferred.await()
-//
-//                Log.d("bandal", "studyRoomDuration: $studyRoomDuration")
-//                Log.d("bandal", "timerDuration: $timerDuration")
-//
-//                _timerState.update { state ->
-//                    when
-//                    state.copy(duration = Duration.ofHours(studyRoomDuration))
-//                }
-//
-//                if (timerDuration == null) {
-//                    timerRepository.clearCurrentTimerDuration()
-//                    return@launch
-//                }
+            viewModelScope.launch {
+                val studyRoomDuration: Long = 1L
+                val timerDuration: TimerDuration? = timerRepository.getCurrentTimerDuration()
 
-//                setTimer(
-//                    startDateTime = timerDuration.startTime,
-//                    duration = Duration.ofHours(studyRoomDuration),
-//                    events = mapOf(Timer.TIME_OVER to {}),
-//                )
-//            }
+                Log.d("bandal", "timerDuration: $timerDuration")
+
+                if (timerDuration == null) {
+                    timerRepository.clearCurrentTimerDuration()
+                    return@launch
+                }
+
+                setTimer(
+                    isAlreadyRunning = true,
+                    startDateTime = timerDuration.startTime,
+                )
+            }
         }
 
         fun setTimer(
+            isAlreadyRunning: Boolean = false,
             startDateTime: LocalDateTime,
-            events: Map<Long, () -> Unit>,
         ) {
-            val duration = Duration.ofHours(studyRoomDuration.value.toLong())
-            timer = Timer(startDateTime, duration, events)
+            val duration: Duration = Duration.ofHours(studyRoomDuration.value.toLong())
+            timer = Timer(startTime = startDateTime, duration = duration)
             timerJob?.cancel()
-            val startTime = Time.create(timer.startTime)
-            val endTime = Time.create(timer.endTime)
-            val leftTime = LeftTime.create(timer.endTime)
+            val startTime: Time = Time.create(timer.startTime)
+            val endTime: Time = Time.create(timer.endTime)
+            val leftTime: LeftTime = LeftTime.create(timer.endTime)
 
             _timerState.update {
                 TimerUiState.Running(
@@ -101,26 +92,16 @@ class TimerViewModel
 
             startTimer()
 
-            timerService.startService(startDateTime, startDateTime.plus(duration))
-
-            viewModelScope.launch {
-                if (timerRepository.getCurrentTimerDuration() == null) {
-                    saveCurrentTimerDuration(startDateTime, duration)
-                }
-            }
-        }
-
-        private fun saveCurrentTimerDuration(
-            startTime: LocalDateTime,
-            duration: Duration,
-        ) {
-            viewModelScope.launch {
-                timerRepository.setCurrentTimerDuration(
-                    TimerDuration(
-                        startTime = startTime,
-                        endTime = startTime.plus(duration),
-                    ),
+            if (isAlreadyRunning.not()) {
+                timerService.startService(
+                    startDateTime = startDateTime,
+                    endDateTime = startDateTime.plus(duration),
                 )
+                viewModelScope.launch {
+                    if (timerRepository.getCurrentTimerDuration() == null) {
+                        saveCurrentTimerDuration(startDateTime, duration)
+                    }
+                }
             }
         }
 
@@ -151,6 +132,20 @@ class TimerViewModel
                         }
                     }
                 }
+        }
+
+        private fun saveCurrentTimerDuration(
+            startTime: LocalDateTime,
+            duration: Duration,
+        ) {
+            viewModelScope.launch {
+                timerRepository.setCurrentTimerDuration(
+                    TimerDuration(
+                        startTime = startTime,
+                        endTime = startTime.plus(duration),
+                    ),
+                )
+            }
         }
 
         fun stopTimer() {

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
@@ -1,6 +1,5 @@
 package com.teamhy2.hongikyeolgong2.timer.presentation
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.teamhy2.hongikyeolgong2.timer.model.Timer
@@ -40,22 +39,19 @@ class TimerViewModel
         private val _errorFlow = MutableSharedFlow<Throwable>()
         val errorFlow: SharedFlow<Throwable> = _errorFlow.asSharedFlow()
 
-        private val studyRoomDuration: MutableStateFlow<Int> = MutableStateFlow(4)
+        private val studyRoomDuration: MutableStateFlow<Int> =
+            MutableStateFlow(TimerRepository.MINIMUM_STUDY_ROOM_HOUR_DURATION)
 
         init {
             viewModelScope.launch {
-                studyRoomDuration.value = 1
-                // FIXME: studyRoomDuration.value = timerRepository.getStudyRoomHourDuration()
+                studyRoomDuration.value = timerRepository.getStudyRoomHourDuration()
             }
             initTimer()
         }
 
         private fun initTimer() {
             viewModelScope.launch {
-                val studyRoomDuration: Long = 1L
                 val timerDuration: TimerDuration? = timerRepository.getCurrentTimerDuration()
-
-                Log.d("bandal", "timerDuration: $timerDuration")
 
                 if (timerDuration == null) {
                     timerRepository.clearCurrentTimerDuration()
@@ -78,7 +74,11 @@ class TimerViewModel
             val duration: Duration = Duration.ofHours(studyRoomDuration.value.toLong())
             timer =
                 if (isAlreadyRunning) {
-                    Timer(startTime = startDateTime, duration = duration, endTime = endDateTime ?: return)
+                    Timer(
+                        startTime = startDateTime,
+                        duration = duration,
+                        endTime = endDateTime ?: return,
+                    )
                 } else {
                     Timer(startTime = startDateTime, duration = duration)
                 }
@@ -180,11 +180,13 @@ class TimerViewModel
                 )
             }
 
+            val startTime = LocalDateTime.now()
+
             viewModelScope.launch {
                 timerRepository.clearCurrentTimerDuration()
                 timerRepository.setCurrentTimerDuration(
                     TimerDuration(
-                        startTime = timer.startTime,
+                        startTime = startTime,
                         endTime = timer.endTime,
                     ),
                 )
@@ -192,7 +194,7 @@ class TimerViewModel
 
             timerService.stopService()
             timerService.startService(
-                startDateTime = timer.startTime,
+                startDateTime = startTime,
                 endDateTime = timer.endTime,
             )
         }

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
@@ -7,7 +7,7 @@ import com.teamhy2.hongikyeolgong2.timer.model.TimerDuration
 import com.teamhy2.hongikyeolgong2.timer.model.TimerRepository
 import com.teamhy2.hongikyeolgong2.timer.model.TimerService
 import com.teamhy2.hongikyeolgong2.timer.presentation.model.LeftTime
-import com.teamhy2.hongikyeolgong2.timer.presentation.model.Time
+import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerTime
 import com.teamhy2.hongikyeolgong2.timer.presentation.model.TimerUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -83,8 +83,8 @@ class TimerViewModel
                     Timer(startTime = startDateTime, duration = duration)
                 }
             timerJob?.cancel()
-            val startTime: Time = Time.create(timer.startTime)
-            val endTime: Time = Time.create(timer.endTime)
+            val startTime: TimerTime = TimerTime.create(timer.startTime)
+            val endTime: TimerTime = TimerTime.create(timer.endTime)
             val leftTime: LeftTime = LeftTime.create(timer.endTime)
 
             _timerState.update {
@@ -171,7 +171,7 @@ class TimerViewModel
         fun extendTime() {
             timer.extend()
 
-            val endTime: Time = Time.create(timer.endTime)
+            val endTime: TimerTime = TimerTime.create(timer.endTime)
 
             _timerState.update { currentState ->
                 (currentState as TimerUiState.Running).copy(

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
@@ -65,6 +65,7 @@ class TimerViewModel
                 setTimer(
                     isAlreadyRunning = true,
                     startDateTime = timerDuration.startTime,
+                    endDateTime = timerDuration.endTime,
                 )
             }
         }
@@ -72,9 +73,15 @@ class TimerViewModel
         fun setTimer(
             isAlreadyRunning: Boolean = false,
             startDateTime: LocalDateTime,
+            endDateTime: LocalDateTime? = null,
         ) {
             val duration: Duration = Duration.ofHours(studyRoomDuration.value.toLong())
-            timer = Timer(startTime = startDateTime, duration = duration)
+            timer =
+                if (isAlreadyRunning) {
+                    Timer(startTime = startDateTime, duration = duration, endTime = endDateTime ?: return)
+                } else {
+                    Timer(startTime = startDateTime, duration = duration)
+                }
             timerJob?.cancel()
             val startTime: Time = Time.create(timer.startTime)
             val endTime: Time = Time.create(timer.endTime)
@@ -86,7 +93,7 @@ class TimerViewModel
                     startTime = startTime,
                     endTime = endTime,
                     leftTime = leftTime,
-                    duration = duration,
+                    duration = Duration.between(startDateTime, timer.endTime),
                 )
             }
 
@@ -159,5 +166,34 @@ class TimerViewModel
             viewModelScope.launch {
                 timerRepository.clearCurrentTimerDuration()
             }
+        }
+
+        fun extendTime() {
+            timer.extend()
+
+            val endTime: Time = Time.create(timer.endTime)
+
+            _timerState.update { currentState ->
+                (currentState as TimerUiState.Running).copy(
+                    endTime = endTime,
+                    duration = Duration.between(timer.startTime, timer.endTime),
+                )
+            }
+
+            viewModelScope.launch {
+                timerRepository.clearCurrentTimerDuration()
+                timerRepository.setCurrentTimerDuration(
+                    TimerDuration(
+                        startTime = timer.startTime,
+                        endTime = timer.endTime,
+                    ),
+                )
+            }
+
+            timerService.stopService()
+            timerService.startService(
+                startDateTime = timer.startTime,
+                endDateTime = timer.endTime,
+            )
         }
     }

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/TimerViewModel.kt
@@ -1,6 +1,5 @@
 package com.teamhy2.hongikyeolgong2.timer.presentation
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.teamhy2.hongikyeolgong2.timer.model.Timer
@@ -15,13 +14,9 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.Duration
@@ -44,19 +39,13 @@ class TimerViewModel
         private val _errorFlow = MutableSharedFlow<Throwable>()
         val errorFlow: SharedFlow<Throwable> = _errorFlow.asSharedFlow()
 
-        private val studyRoomDuration: StateFlow<Int> =
-            flow { emit(timerRepository.getStudyRoomHourDuration()) }
-                .catch { throwable ->
-                    _errorFlow.emit(throwable)
-                }
-                .stateIn(
-                    scope = viewModelScope,
-                    started = SharingStarted.WhileSubscribed(5000),
-                    initialValue = 1,
-                )
+        private val studyRoomDuration: MutableStateFlow<Int> = MutableStateFlow(4)
 
         init {
-//            initTimer()
+            viewModelScope.launch {
+                studyRoomDuration.value = 1
+                // FIXME: studyRoomDuration.value = timerRepository.getStudyRoomHourDuration()
+            }
         }
 
         private fun initTimer() {
@@ -93,8 +82,6 @@ class TimerViewModel
             startDateTime: LocalDateTime,
             events: Map<Long, () -> Unit>,
         ) {
-            Log.d("bandal", "setTimer: 호출")
-
             val duration = Duration.ofHours(studyRoomDuration.value.toLong())
             timer = Timer(startDateTime, duration, events)
             timerJob?.cancel()

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/LeftTime.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/LeftTime.kt
@@ -11,7 +11,7 @@ value class LeftTime(val value: String) {
         private const val TIME_OVER = "00:00:00"
 
         fun create(endTime: LocalDateTime): LeftTime {
-            val now = LocalDateTime.now()
+            val now: LocalDateTime = LocalDateTime.now()
             if (now.isAfter(endTime)) {
                 return LeftTime(TIME_OVER)
             }

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/LeftTime.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/LeftTime.kt
@@ -1,0 +1,31 @@
+package com.teamhy2.hongikyeolgong2.timer.presentation.model
+
+import java.time.Duration
+import java.time.LocalDateTime
+import java.util.Locale
+
+@JvmInline
+value class LeftTime(val value: String) {
+    companion object {
+        private const val LEFT_TIME_FORMAT: String = "%02d:%02d:%02d"
+
+        fun create(endTime: LocalDateTime): LeftTime {
+            val now = LocalDateTime.now()
+            if (now.isAfter(endTime)) {
+                val timeOver = String.format(Locale.KOREA, LEFT_TIME_FORMAT, 0, 0, 0)
+                return LeftTime(timeOver)
+            }
+
+            val leftTime: Duration = Duration.between(now, endTime)
+            val formattedLeftTime =
+                String.format(
+                    Locale.KOREA,
+                    LEFT_TIME_FORMAT,
+                    leftTime.toHours(),
+                    leftTime.toMinutes() % 60,
+                    leftTime.seconds % 60,
+                )
+            return LeftTime(formattedLeftTime)
+        }
+    }
+}

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/LeftTime.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/LeftTime.kt
@@ -8,12 +8,12 @@ import java.util.Locale
 value class LeftTime(val value: String) {
     companion object {
         private const val LEFT_TIME_FORMAT: String = "%02d:%02d:%02d"
+        private const val TIME_OVER = "00:00:00"
 
         fun create(endTime: LocalDateTime): LeftTime {
             val now = LocalDateTime.now()
             if (now.isAfter(endTime)) {
-                val timeOver = String.format(Locale.KOREA, LEFT_TIME_FORMAT, 0, 0, 0)
-                return LeftTime(timeOver)
+                return LeftTime(TIME_OVER)
             }
 
             val leftTime: Duration = Duration.between(now, endTime)

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/Meridiem.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/Meridiem.kt
@@ -1,0 +1,6 @@
+package com.teamhy2.hongikyeolgong2.timer.presentation.model
+
+enum class Meridiem(val label: String) {
+    PM("PM"),
+    AM("AM"),
+}

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/Time.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/Time.kt
@@ -1,0 +1,31 @@
+package com.teamhy2.hongikyeolgong2.timer.presentation.model
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+data class Time(
+    val meridiem: Meridiem,
+    val hour: String,
+    val minute: String,
+) {
+    val hourAndMinute: String
+        get() = "$hour:$minute"
+
+    companion object {
+        private const val HIGH_NOON = 12
+        private const val START_END_TIME_FORMAT: String = "hh:mm"
+        private val timeFormatter: DateTimeFormatter =
+            DateTimeFormatter.ofPattern(START_END_TIME_FORMAT)
+
+        fun create(localDateTime: LocalDateTime): Time {
+            val meridiem: Meridiem = if (localDateTime.hour >= HIGH_NOON) Meridiem.PM else Meridiem.AM
+            val hourAndMinute: String = localDateTime.format(timeFormatter)
+            val (hour, minute) = hourAndMinute.split(":")
+            return Time(
+                meridiem = meridiem,
+                hour = hour,
+                minute = minute,
+            )
+        }
+    }
+}

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/TimerTime.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/TimerTime.kt
@@ -3,12 +3,12 @@ package com.teamhy2.hongikyeolgong2.timer.presentation.model
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-data class Time(
+data class TimerTime(
     val meridiem: Meridiem,
     val hour: String,
     val minute: String,
 ) {
-    val hourAndMinute: String
+    val formattedTime: String
         get() = "$hour:$minute"
 
     companion object {
@@ -17,11 +17,11 @@ data class Time(
         private val timeFormatter: DateTimeFormatter =
             DateTimeFormatter.ofPattern(START_END_TIME_FORMAT)
 
-        fun create(localDateTime: LocalDateTime): Time {
+        fun create(localDateTime: LocalDateTime): TimerTime {
             val meridiem: Meridiem = if (localDateTime.hour >= HIGH_NOON) Meridiem.PM else Meridiem.AM
             val hourAndMinute: String = localDateTime.format(timeFormatter)
             val (hour, minute) = hourAndMinute.split(":")
-            return Time(
+            return TimerTime(
                 meridiem = meridiem,
                 hour = hour,
                 minute = minute,

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/TimerUiState.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/TimerUiState.kt
@@ -1,5 +1,6 @@
 package com.teamhy2.hongikyeolgong2.timer.presentation.model
 
+import java.time.Duration
 import java.time.LocalDateTime
 
 data class TimerUiState(
@@ -9,5 +10,6 @@ data class TimerUiState(
     val endTime: String = "",
     val endTimeMeridiem: String = "",
     val leftTime: String = "",
+    val duration: Duration = Duration.ZERO,
     val isRunning: Boolean = false,
 )

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/TimerUiState.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/TimerUiState.kt
@@ -11,6 +11,6 @@ sealed interface TimerUiState {
         val startTime: Time,
         val endTime: Time,
         val leftTime: LeftTime,
-        val duration: Duration = Duration.ZERO,
+        val duration: Duration,
     ) : TimerUiState
 }

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/TimerUiState.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/TimerUiState.kt
@@ -8,8 +8,8 @@ sealed interface TimerUiState {
 
     data class Running(
         val startDateTime: LocalDateTime,
-        val startTime: Time,
-        val endTime: Time,
+        val startTime: TimerTime,
+        val endTime: TimerTime,
         val leftTime: LeftTime,
         val duration: Duration,
     ) : TimerUiState

--- a/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/TimerUiState.kt
+++ b/timer-presentation/src/main/java/com/teamhy2/hongikyeolgong2/timer/presentation/model/TimerUiState.kt
@@ -3,13 +3,14 @@ package com.teamhy2.hongikyeolgong2.timer.presentation.model
 import java.time.Duration
 import java.time.LocalDateTime
 
-data class TimerUiState(
-    val startDateTime: LocalDateTime = LocalDateTime.now(),
-    val startTime: String = "",
-    val startTimeMeridiem: String = "",
-    val endTime: String = "",
-    val endTimeMeridiem: String = "",
-    val leftTime: String = "",
-    val duration: Duration = Duration.ZERO,
-    val isRunning: Boolean = false,
-)
+sealed interface TimerUiState {
+    data object Idle : TimerUiState
+
+    data class Running(
+        val startDateTime: LocalDateTime,
+        val startTime: Time,
+        val endTime: Time,
+        val leftTime: LeftTime,
+        val duration: Duration = Duration.ZERO,
+    ) : TimerUiState
+}


### PR DESCRIPTION
resolved #137 
resolved #138

## AS-IS
- 타이머에서 뷰로직포함
- 홈뷰모델에서 타이머관련 로직 포함
- 최근앱에서 제거하면 서비스는 돌아도 뷰는 복구되지 않았음

## TO-BE
- 타이머에서 뷰로직 제거
- 홈뷰모델에서 타이머관련 로직 제거
- 최근 앱에서 제거해도 뷰 복구 되게 변경


## KEY-POINT
- 홈에서 각종 다이얼로그들이 떠있는지에 대한 상태까지 UIState로 다루는 것을 분리하였습니다.
- 프로모션 다이얼로그는 프로모션에 대한 데이터에 따라 다이얼로그를 표시할지 말지를 정함으로 뷰모델에서 관리하는게 맞지만, 다른 다이얼로그들은 HomeScreen 딴에서 자체적으로 처리가 가능하다 판단하여 분리하였습니다.
- 상태 호이스팅은 필요한 곳 까지만 올리는 것이 유리합니다.

- QA용 앱은 메일로 보내드렸습니다 :)
