### PR TITLE
[Feature] 프로필 수정 기능을 구현합니다.

### DIFF
--- a/build-logic/src/main/java/hongikyeolgong2.android.feature.gradle.kts
+++ b/build-logic/src/main/java/hongikyeolgong2.android.feature.gradle.kts
@@ -25,4 +25,10 @@ dependencies {
 
 	implementation(libs.findLibrary("androidx.lifecycle.viewModelCompose").get())
 	implementation(libs.findLibrary("androidx.lifecycle.runtimeCompose").get())
+
+    // MVI - Orbit
+    implementation(libs.findLibrary("orbit.core").get())
+    implementation(libs.findLibrary("orbit.viewmodel").get())
+    implementation(libs.findLibrary("orbit.compose").get())
+    implementation(libs.findLibrary("orbit.test").get())
 }

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -10,4 +10,5 @@ android {
 dependencies {
     implementation(libs.androidx.appcompat)
     implementation(projects.core.tracker)
+    implementation(libs.androidx.navigation.runtime.ktx)
 }

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/common/HY2Dialog.kt
@@ -78,7 +78,6 @@ fun HY2Dialog(
                     text = description,
                     color = descriptionTextColor,
                     style = HY2Theme.typography.title02,
-                    modifier = Modifier.padding(bottom = 16.dp),
                 )
                 Spacer(modifier = Modifier.height(32.dp))
                 Row(
@@ -143,9 +142,9 @@ private fun HY2DialogPreview() {
             description = "로그아웃 하실 건가요?",
             leftButtonText = "로그아웃하기",
             rightButtonText = "돌아가기",
-            onLeftButtonClick = { /* TODO */ },
-            onRightButtonClick = { /* TODO */ },
-            onDismiss = { /* TODO */ },
+            onLeftButtonClick = {},
+            onRightButtonClick = {},
+            onDismiss = {},
         )
     }
 }

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/ui/theme/Type.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/ui/theme/Type.kt
@@ -32,6 +32,7 @@ class HY2Typography(
     body04: TextStyle,
     body05: TextStyle,
     body06: TextStyle,
+    body07: TextStyle,
     caption: TextStyle,
 ) {
     var head: TextStyle by mutableStateOf(head)
@@ -54,6 +55,8 @@ class HY2Typography(
         private set
     var body06: TextStyle by mutableStateOf(body06)
         private set
+    var body07: TextStyle by mutableStateOf(body07)
+        private set
     var caption: TextStyle by mutableStateOf(caption)
         private set
 
@@ -68,6 +71,7 @@ class HY2Typography(
         body04: TextStyle = this.body04,
         body05: TextStyle = this.body05,
         body06: TextStyle = this.body06,
+        body07: TextStyle = this.body07,
         caption: TextStyle = this.caption,
     ): HY2Typography =
         HY2Typography(
@@ -81,6 +85,7 @@ class HY2Typography(
             body04,
             body05,
             body06,
+            body07,
             caption,
         )
 
@@ -95,6 +100,7 @@ class HY2Typography(
         body04 = other.body04
         body05 = other.body05
         body06 = other.body06
+        body07 = other.body07
         caption = other.caption
     }
 }
@@ -161,6 +167,12 @@ fun HY2Typography(): HY2Typography {
                 fontFamily = PretendardRegular,
                 fontSize = 18.sp,
                 lineHeight = 26.sp,
+            ),
+        body07 =
+            TextStyle(
+                fontFamily = PretendardRegular,
+                fontSize = 14.sp,
+                lineHeight = 20.sp,
             ),
         caption =
             TextStyle(

--- a/core/designsystem/src/main/java/com/teamhy2/designsystem/util/compositionlocal/LocalNavController.kt
+++ b/core/designsystem/src/main/java/com/teamhy2/designsystem/util/compositionlocal/LocalNavController.kt
@@ -1,0 +1,9 @@
+package com.teamhy2.designsystem.util.compositionlocal
+
+import androidx.compose.runtime.compositionLocalOf
+import androidx.navigation.NavController
+
+val LocalNavController =
+    compositionLocalOf<NavController> {
+        throw Error("NavController가 제공되지 않았습니다.")
+    }

--- a/core/remote/src/main/java/com/benenfeldt/remote/api/UserService.kt
+++ b/core/remote/src/main/java/com/benenfeldt/remote/api/UserService.kt
@@ -1,6 +1,7 @@
 package com.benenfeldt.remote.api
 
 import com.benenfeldt.remote.dto.BaseResponse
+import com.benenfeldt.remote.dto.UserInfoRequest
 import com.benenfeldt.remote.dto.UserInfoResponse
 import com.benenfeldt.remote.dto.UserSignUpRequest
 import com.benenfeldt.remote.dto.UserSignUpResponse
@@ -8,6 +9,7 @@ import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.PUT
 
 interface UserService {
     @POST("/api/v1/user/join")
@@ -20,4 +22,9 @@ interface UserService {
 
     @GET("/api/v1/user/me")
     suspend fun getUserInfo(): Result<BaseResponse<UserInfoResponse>>
+
+    @PUT("/api/v1/user")
+    suspend fun modifyUserInfo(
+        @Body userInfoRequest: UserInfoRequest,
+    ): Result<BaseResponse<UserInfoResponse>>
 }

--- a/core/remote/src/main/java/com/benenfeldt/remote/dto/UserInfoRequest.kt
+++ b/core/remote/src/main/java/com/benenfeldt/remote/dto/UserInfoRequest.kt
@@ -1,0 +1,9 @@
+package com.benenfeldt.remote.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserInfoRequest(
+    val nickname: String,
+    val department: String,
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,9 @@ credentials = "1.3.0-alpha01"
 googleid = "1.1.1"
 firebaseConfigKtx = "22.0.1"
 
+# MVI - Oribt
+orbit = "9.0.0"
+
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -142,6 +145,12 @@ googleid = { module = "com.google.android.libraries.identity.googleid:googleid",
 
 # Amplitude
 amplitude = { module = "com.amplitude:analytics-android", version.ref = "amplitude" }
+
+# MVI - Orbit
+orbit-compose = { module = "org.orbit-mvi:orbit-compose", version.ref = "orbit" }
+orbit-core = { module = "org.orbit-mvi:orbit-core", version.ref = "orbit" }
+orbit-test = { module = "org.orbit-mvi:orbit-test", version.ref = "orbit" }
+orbit-viewmodel = { module = "org.orbit-mvi:orbit-viewmodel", version.ref = "orbit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,7 @@ firebaseConfigKtx = "22.0.1"
 
 # MVI - Oribt
 orbit = "9.0.0"
+navigationRuntimeKtx = "2.8.5"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }
@@ -65,6 +66,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navigation-runtime-ktx", version.ref = "navigationRuntimeKtx" }
 
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/MainActivity.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/MainActivity.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.draw.paint
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -37,6 +38,7 @@ import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 import com.teamhy2.designsystem.common.HY2LoadingScreen
 import com.teamhy2.designsystem.ui.theme.HY2Theme
+import com.teamhy2.designsystem.util.compositionlocal.LocalNavController
 import com.teamhy2.designsystem.util.compositionlocal.LocalShowSnackBar
 import com.teamhy2.designsystem.util.compositionlocal.LocalTracker
 import com.teamhy2.designsystem.util.compositionlocal.ShowSnackBar
@@ -69,7 +71,7 @@ class MainActivity : AppCompatActivity() {
         enableEdgeToEdge()
         setContent {
             HY2Theme {
-                val navController = rememberNavController()
+                val navController: NavHostController = rememberNavController()
                 val currentBackStackEntry by navController.currentBackStackEntryAsState()
                 val currentDestination = currentBackStackEntry?.destination?.route
 
@@ -140,6 +142,7 @@ class MainActivity : AppCompatActivity() {
                                 CompositionLocalProvider(
                                     LocalTracker provides tracker,
                                     LocalShowSnackBar provides showSnackBar,
+                                    LocalNavController provides navController,
                                 ) {
                                     LaunchedEffect(true) {
                                         initialViewModel.errorFlow.collectLatest {

--- a/setting-presentation/build.gradle.kts
+++ b/setting-presentation/build.gradle.kts
@@ -12,4 +12,6 @@ dependencies {
     implementation(projects.userDomain)
     implementation(libs.coil)
     implementation(projects.core.tracker)
+    implementation(projects.onboardingPresentation)
+    implementation(projects.onboardingDomain)
 }

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/ProfileModificationContract.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/ProfileModificationContract.kt
@@ -1,0 +1,21 @@
+package com.teamhy2.feature.setting.presentation
+
+import com.teamhy2.onboarding.NicknameState
+import com.teamhy2.user.domain.model.UserInfo
+
+data class ProfileModificationState(
+    val isLoading: Boolean = false,
+    val userInfo: UserInfo = UserInfo.LOADING,
+    val departments: List<String> = emptyList(),
+    val isNicknameValidate: Boolean = false,
+    val nicknameState: NicknameState = NicknameState.NOT_CHECKED,
+    val isDepartmentValidate: Boolean = false,
+)
+
+sealed interface ProfileModificationSideEffect {
+    data class ShowError(val throwable: Throwable) : ProfileModificationSideEffect
+
+    data object ProfileModificationSucceed : ProfileModificationSideEffect
+
+    data object ProfileModificationFailure : ProfileModificationSideEffect
+}

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/ProfileModificationScreen.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/ProfileModificationScreen.kt
@@ -1,0 +1,311 @@
+package com.teamhy2.feature.setting.presentation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.paint
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import com.teamhy2.designsystem.common.HY2Dialog
+import com.teamhy2.designsystem.common.HY2DropdownTextField
+import com.teamhy2.designsystem.common.HY2TextField
+import com.teamhy2.designsystem.common.ThrottleButton
+import com.teamhy2.designsystem.ui.theme.BackgroundBlack
+import com.teamhy2.designsystem.ui.theme.Blue100
+import com.teamhy2.designsystem.ui.theme.Blue400
+import com.teamhy2.designsystem.ui.theme.Gray100
+import com.teamhy2.designsystem.ui.theme.Gray200
+import com.teamhy2.designsystem.ui.theme.Gray400
+import com.teamhy2.designsystem.ui.theme.HY2Theme
+import com.teamhy2.designsystem.ui.theme.HY2Typography
+import com.teamhy2.designsystem.ui.theme.White
+import com.teamhy2.designsystem.ui.theme.Yellow300
+import com.teamhy2.designsystem.util.compositionlocal.LocalNavController
+import com.teamhy2.designsystem.util.compositionlocal.LocalShowSnackBar
+import com.teamhy2.designsystem.util.compositionlocal.ShowSnackBar
+import com.teamhy2.designsystem.util.modifier.addFocusCleaner
+import com.teamhy2.designsystem.util.modifier.throttleClickable
+import com.teamhy2.onboarding.NicknameState
+import com.teamhy2.onboarding.presentation.R
+import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
+
+@Composable
+fun ProfileModificationRoute(profileModificationViewModel: ProfileModificationViewModel = hiltViewModel()) {
+    val localShowSnackBar: ShowSnackBar = LocalShowSnackBar.current
+    val localNavController: NavController = LocalNavController.current
+    val state by profileModificationViewModel.collectAsState()
+
+    profileModificationViewModel.collectSideEffect {
+        when (it) {
+            is ProfileModificationSideEffect.ShowError -> localShowSnackBar.showSnackBar(it.throwable.message)
+            is ProfileModificationSideEffect.ProfileModificationFailure -> {
+                localShowSnackBar.showSnackBar("프로필 수정에 실패하였습니다.")
+            }
+
+            is ProfileModificationSideEffect.ProfileModificationSucceed -> {
+                localNavController.popBackStack()
+            }
+        }
+    }
+
+    ProfileModificationScreen(
+        nickname = state.userInfo.nickname,
+        isNicknameValidate = state.isNicknameValidate,
+        nicknameState = state.nicknameState,
+        isDepartmentValidate = state.isDepartmentValidate,
+        department = state.userInfo.department,
+        departments = state.departments,
+        onDepartmentChange = profileModificationViewModel::updateDepartment,
+        onNicknameChange = profileModificationViewModel::updateNickname,
+        onNicknameDuplicateCheckClicked = profileModificationViewModel::checkNicknameDuplication,
+        onModificationButtonClicked = profileModificationViewModel::updateUserInfo,
+        onBackClick = { localNavController.popBackStack() },
+    )
+}
+
+@Composable
+fun ProfileModificationScreen(
+    nickname: String,
+    isNicknameValidate: Boolean,
+    nicknameState: NicknameState,
+    isDepartmentValidate: Boolean,
+    department: String,
+    departments: List<String>,
+    onDepartmentChange: (String) -> Unit,
+    onNicknameChange: (String) -> Unit,
+    onNicknameDuplicateCheckClicked: () -> Unit,
+    onModificationButtonClicked: () -> Unit,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusRequester by remember { mutableStateOf(FocusRequester()) }
+    val focusManager = LocalFocusManager.current
+
+    var isAskAgainDialogOpen by remember { mutableStateOf(false) }
+
+    if (isAskAgainDialogOpen) {
+        HY2Dialog(
+            description = "프로필 변경을 진행하실건가요?",
+            leftButtonText = "돌아가기",
+            rightButtonText = "변경하기",
+            onLeftButtonClick = { isAskAgainDialogOpen = false },
+            onRightButtonClick = {
+                onModificationButtonClicked()
+                isAskAgainDialogOpen = false
+            },
+            onDismiss = { isAskAgainDialogOpen = false },
+        )
+    }
+
+    Column(
+        modifier =
+            modifier
+                .background(BackgroundBlack)
+                .addFocusCleaner(focusManager)
+                .padding(horizontal = 32.dp),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(52.dp)
+                    .offset(x = (-8).dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier =
+                    Modifier.size(40.dp)
+                        .clip(CircleShape)
+                        .throttleClickable(onClick = onBackClick),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    painter = painterResource(id = com.teamhy2.hongikyeolgong2.setting.presentation.R.drawable.ic_back),
+                    contentDescription = null,
+                    tint = Gray100,
+                )
+            }
+            Text(
+                text = "프로필 변경",
+                style = HY2Typography().head,
+                color = Gray100,
+            )
+        }
+        Spacer(modifier = Modifier.height(22.dp))
+        Text(
+            text = stringResource(R.string.sign_up_nickname_title),
+            style = HY2Typography().title03,
+            color = Gray200,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Row {
+            HY2TextField(
+                value = nickname,
+                onValueChange = onNicknameChange,
+                modifier = Modifier.weight(1f),
+                focusRequester = focusRequester,
+                hintText = stringResource(R.string.sign_up_nickname_hint),
+                isInvalid = isNicknameValidate.not() || nicknameState == NicknameState.DUPLICATED,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            ThrottleButton(
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = Blue100,
+                        disabledContainerColor = Blue400,
+                    ),
+                shape = RoundedCornerShape(8.dp),
+                onClick = onNicknameDuplicateCheckClicked,
+                enabled = isNicknameValidate && nicknameState == NicknameState.NOT_CHECKED,
+                modifier = Modifier.height(48.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.sign_up_duplication_check),
+                    style = HY2Typography().body05,
+                    color =
+                        if (nicknameState == NicknameState.DUPLICATED ||
+                            nicknameState == NicknameState.NOT_DUPLICATED ||
+                            isNicknameValidate.not()
+                        ) {
+                            White.copy(
+                                alpha = 0.4f,
+                            )
+                        } else {
+                            White
+                        },
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text =
+                when {
+                    nickname.isEmpty() -> stringResource(id = R.string.sign_up_nickname_hint_text)
+                    nicknameState == NicknameState.DUPLICATED -> stringResource(id = R.string.sign_up_nickname_duplicated)
+                    isNicknameValidate && nicknameState == NicknameState.NOT_CHECKED ->
+                        stringResource(
+                            id = R.string.sign_up_nickname_hint_text,
+                        )
+
+                    isNicknameValidate -> stringResource(id = R.string.sign_up_nickname_can_use_text)
+                    else -> stringResource(R.string.sign_up_nickname_error_text)
+                },
+            style = HY2Typography().caption,
+            color =
+                if (nickname.isBlank()) {
+                    Gray400
+                } else if (isNicknameValidate.not() || nicknameState == NicknameState.DUPLICATED) {
+                    Yellow300
+                } else {
+                    Blue100
+                },
+        )
+        Spacer(modifier = Modifier.height(32.dp))
+        Text(
+            text = stringResource(R.string.sign_up_department_title),
+            style = HY2Typography().title03,
+            color = Gray200,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        HY2DropdownTextField(
+            options = departments,
+            hintText = stringResource(R.string.sign_up_department_hint),
+            value = department,
+            onValueChanged = onDepartmentChange,
+            focusManager = focusManager,
+            focusRequester = focusRequester,
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        HY2GradientMainButton(
+            onClick = { isAskAgainDialogOpen = true },
+            text = "변경하기",
+            enabled = nicknameState == NicknameState.NOT_DUPLICATED && isNicknameValidate && isDepartmentValidate,
+        )
+        Spacer(modifier = Modifier.height(32.dp))
+    }
+}
+
+@Composable
+private fun HY2GradientMainButton(
+    onClick: () -> Unit,
+    text: String,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .paint(
+                    painter =
+                        painterResource(
+                            id = if (enabled) R.drawable.img_gradient_main_button_enabled else R.drawable.img_gradient_main_button_disabled,
+                        ),
+                    contentScale = ContentScale.Fit,
+                )
+                .throttleClickable(
+                    enabled = enabled,
+                    onClick = onClick,
+                ),
+    ) {
+        Text(
+            text = text,
+            style = HY2Typography().title02,
+            color = if (enabled) Gray100 else Gray100.copy(alpha = 0.5f),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ProfileModificationScreenPreview() {
+    var nickname by remember { mutableStateOf("") }
+
+    HY2Theme {
+        ProfileModificationScreen(
+            nickname = nickname,
+            isNicknameValidate = false,
+            nicknameState = NicknameState.NOT_CHECKED,
+            isDepartmentValidate = false,
+            onNicknameChange = { nickname = it },
+            onNicknameDuplicateCheckClicked = {},
+            departments = emptyList(),
+            department = "",
+            onModificationButtonClicked = {},
+            onDepartmentChange = {},
+            onBackClick = {},
+        )
+    }
+}

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/ProfileModificationViewModel.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/ProfileModificationViewModel.kt
@@ -1,0 +1,117 @@
+package com.teamhy2.feature.setting.presentation
+
+import androidx.lifecycle.ViewModel
+import com.teamhy2.onboarding.NicknameState
+import com.teamhy2.onboarding.domain.model.NicknameValidation
+import com.teamhy2.onboarding.domain.repository.DepartmentRepository
+import com.teamhy2.user.domain.repository.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import org.orbitmvi.orbit.Container
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.viewmodel.container
+import javax.inject.Inject
+
+@HiltViewModel
+class ProfileModificationViewModel
+    @Inject
+    constructor(
+        private val userRepository: UserRepository,
+        private val departmentRepository: DepartmentRepository,
+    ) : ViewModel(), ContainerHost<ProfileModificationState, ProfileModificationSideEffect> {
+        override val container: Container<ProfileModificationState, ProfileModificationSideEffect> =
+            container(ProfileModificationState())
+
+        init {
+            initSettingUiState()
+        }
+
+        private fun initSettingUiState() =
+            intent {
+                reduce { state.copy(isLoading = true) }
+                val departments = departmentRepository.getAllDepartments()
+
+                userRepository.getUserInfo()
+                    .onSuccess { userInfo ->
+                        reduce {
+                            state.copy(
+                                isLoading = false,
+                                userInfo = userInfo,
+                                departments = departments,
+                                nicknameState = NicknameState.DUPLICATED,
+                                isNicknameValidate = true,
+                                isDepartmentValidate = true,
+                            )
+                        }
+                    }
+                    .onFailure { throwable ->
+                        reduce { state.copy(isLoading = false) }
+                        postSideEffect(ProfileModificationSideEffect.ShowError(throwable))
+                    }
+            }
+
+        fun updateNickname(value: String) =
+            intent {
+                reduce {
+                    state.copy(
+                        userInfo = state.userInfo.copy(nickname = value),
+                        nicknameState = NicknameState.NOT_CHECKED,
+                    )
+                }
+                checkNicknameValidation()
+            }
+
+        private fun checkNicknameValidation() =
+            intent {
+                reduce {
+                    state.copy(isNicknameValidate = NicknameValidation.validate(state.userInfo.nickname))
+                }
+            }
+
+        fun updateDepartment(value: String) =
+            intent {
+                reduce {
+                    state.copy(
+                        userInfo = state.userInfo.copy(department = value),
+                    )
+                }
+                checkDepartmentValidation()
+            }
+
+        private fun checkDepartmentValidation() =
+            intent {
+                reduce {
+                    state.copy(
+                        isDepartmentValidate = state.departments.find { it == state.userInfo.department } != null,
+                    )
+                }
+            }
+
+        fun checkNicknameDuplication() =
+            intent {
+                userRepository.checkNicknameDuplication(state.userInfo.nickname)
+                    .onSuccess { isDuplicated ->
+                        if (isDuplicated) {
+                            reduce { state.copy(nicknameState = NicknameState.DUPLICATED) }
+                            return@onSuccess
+                        }
+                        reduce { state.copy(nicknameState = NicknameState.NOT_DUPLICATED) }
+                    }
+                    .onFailure { throwable ->
+                        postSideEffect(ProfileModificationSideEffect.ShowError(throwable))
+                    }
+            }
+
+        fun updateUserInfo() =
+            intent {
+                reduce { state.copy(isLoading = true) }
+                userRepository.modifyUserInfo(state.userInfo.nickname, state.userInfo.department)
+                    .onSuccess {
+                        reduce { state.copy(isLoading = false) }
+                        postSideEffect(ProfileModificationSideEffect.ProfileModificationSucceed)
+                    }
+                    .onFailure {
+                        reduce { state.copy(isLoading = false) }
+                        postSideEffect(ProfileModificationSideEffect.ProfileModificationFailure)
+                    }
+            }
+    }

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingScreen.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingScreen.kt
@@ -36,12 +36,14 @@ import com.teamhy2.designsystem.common.HY2Dialog
 import com.teamhy2.designsystem.ui.theme.Gray300
 import com.teamhy2.designsystem.ui.theme.HY2Theme
 import com.teamhy2.designsystem.ui.theme.HY2Typography
+import com.teamhy2.designsystem.util.compositionlocal.LocalNavController
 import com.teamhy2.designsystem.util.compositionlocal.LocalShowSnackBar
 import com.teamhy2.designsystem.util.compositionlocal.LocalTracker
 import com.teamhy2.feature.setting.presentation.components.SettingButton
 import com.teamhy2.feature.setting.presentation.components.SettingButtonWithSwitch
 import com.teamhy2.feature.setting.presentation.components.SettingUserProfile
 import com.teamhy2.feature.setting.presentation.model.SettingUiState
+import com.teamhy2.feature.setting.presentation.navigation.navigateToProfileModification
 import com.teamhy2.hongikyeolgong2.setting.presentation.R
 import com.teamhy2.user.domain.model.UserInfo
 import kotlinx.coroutines.flow.collectLatest
@@ -59,8 +61,11 @@ fun SettingRoute(
     val tracker = LocalTracker.current
 
     val localShowSnackBar = LocalShowSnackBar.current
+    val localNavController = LocalNavController.current
+
     LaunchedEffect(true) {
         tracker.trackEvent("Setting")
+        viewModel.initSettingUiState()
         viewModel.errorFlow.collectLatest { throwable ->
             localShowSnackBar.showSnackBar(throwable.message)
         }
@@ -85,9 +90,7 @@ fun SettingRoute(
         },
         onInquiryClick = onInquiryClick,
         onSignOutOrWithdrawComplete = onSignOutOrWithdrawComplete,
-        onProfileClick = {
-            // TODO: 프로필 클릭시 프로필 수정 화면 이동
-        },
+        onProfileModifyClick = { localNavController.navigateToProfileModification() },
         modifier = modifier,
     )
 }
@@ -100,7 +103,7 @@ fun SettingScreen(
     onNotificationSwitchClick: (Boolean) -> Unit,
     onNoticeClick: () -> Unit,
     onInquiryClick: () -> Unit,
-    onProfileClick: () -> Unit,
+    onProfileModifyClick: () -> Unit,
     onSignOutOrWithdrawComplete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -154,7 +157,7 @@ fun SettingScreen(
                     onNotificationSwitchClick = onNotificationSwitchClick,
                     onNoticeClick = onNoticeClick,
                     onInquiryClick = onInquiryClick,
-                    onProfileClick = onProfileClick,
+                    onProfileClick = onProfileModifyClick,
                 )
 
                 Spacer(modifier = Modifier.weight(1f))
@@ -307,7 +310,7 @@ private fun SettingScreenPreview() {
             onNoticeClick = {},
             onInquiryClick = {},
             onSignOutOrWithdrawComplete = {},
-            onProfileClick = {},
+            onProfileModifyClick = {},
             modifier = Modifier,
         )
     }

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingScreen.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingScreen.kt
@@ -85,6 +85,9 @@ fun SettingRoute(
         },
         onInquiryClick = onInquiryClick,
         onSignOutOrWithdrawComplete = onSignOutOrWithdrawComplete,
+        onProfileClick = {
+            // TODO: 프로필 클릭시 프로필 수정 화면 이동
+        },
         modifier = modifier,
     )
 }
@@ -97,6 +100,7 @@ fun SettingScreen(
     onNotificationSwitchClick: (Boolean) -> Unit,
     onNoticeClick: () -> Unit,
     onInquiryClick: () -> Unit,
+    onProfileClick: () -> Unit,
     onSignOutOrWithdrawComplete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -150,6 +154,7 @@ fun SettingScreen(
                     onNotificationSwitchClick = onNotificationSwitchClick,
                     onNoticeClick = onNoticeClick,
                     onInquiryClick = onInquiryClick,
+                    onProfileClick = onProfileClick,
                 )
 
                 Spacer(modifier = Modifier.weight(1f))
@@ -176,6 +181,7 @@ fun SettingBody(
     onNotificationSwitchClick: (Boolean) -> Unit,
     onNoticeClick: () -> Unit,
     onInquiryClick: () -> Unit,
+    onProfileClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -185,8 +191,11 @@ fun SettingBody(
                 .fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        SettingUserProfile(userInfo)
-        Spacer(modifier = Modifier.height(20.dp))
+        SettingUserProfile(
+            userInfo = userInfo,
+            onProfileClick = onProfileClick,
+        )
+        Spacer(modifier = Modifier.height(24.dp))
         SettingButton(
             text = stringResource(R.string.setting_notice),
             onClick = onNoticeClick,
@@ -270,7 +279,7 @@ fun SettingBottom(
     }
 }
 
-@Preview(showBackground = true)
+@Preview(showBackground = true, backgroundColor = 0xFF000000)
 @Composable
 private fun SettingScreenPreview() {
     val sampleUserInfo =
@@ -298,6 +307,7 @@ private fun SettingScreenPreview() {
             onNoticeClick = {},
             onInquiryClick = {},
             onSignOutOrWithdrawComplete = {},
+            onProfileClick = {},
             modifier = Modifier,
         )
     }

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingViewModel.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingViewModel.kt
@@ -30,11 +30,7 @@ class SettingViewModel
         private val _errorFlow = MutableSharedFlow<Throwable>()
         val errorFlow: SharedFlow<Throwable> = _errorFlow.asSharedFlow()
 
-        init {
-            initSettingUiState()
-        }
-
-        private fun initSettingUiState() {
+        fun initSettingUiState() {
             viewModelScope.launch {
                 val userInfoResult = userRepository.getUserInfo()
                 settingsRepository.notificationSwitchState.collectLatest { isNotificationSwitchChecked ->

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/components/SettingUserProfile.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/components/SettingUserProfile.kt
@@ -1,25 +1,28 @@
 package com.teamhy2.feature.setting.presentation.components
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Icon
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import com.teamhy2.designsystem.ui.theme.Gray100
+import com.teamhy2.designsystem.ui.theme.Gray200
+import com.teamhy2.designsystem.ui.theme.Gray800
 import com.teamhy2.designsystem.ui.theme.HY2Typography
 import com.teamhy2.designsystem.util.modifier.throttleClickable
-import com.teamhy2.hongikyeolgong2.setting.presentation.R
 import com.teamhy2.hongikyeolgong2.setting.presentation.R.drawable.img_settting_profile
 import com.teamhy2.user.domain.model.UserInfo
 
@@ -41,7 +44,10 @@ fun SettingUserProfile(
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier.fillMaxWidth().throttleClickable(onClick = onProfileClick),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .throttleClickable(onClick = onProfileClick),
     ) {
         Image(
             painter = profileImagePainter,
@@ -49,24 +55,33 @@ fun SettingUserProfile(
             modifier = Modifier.size(PROFILE_IMAGE_SIZE.dp),
         )
         Spacer(modifier = Modifier.height(12.dp))
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                text = userInfo.nickname,
-                style = HY2Typography().title02,
-                color = Gray100,
-            )
-            Icon(
-                painterResource(id = R.drawable.ic_arrow_right),
-                contentDescription = null,
-                tint = Gray100,
-            )
-        }
+        Text(
+            text = userInfo.nickname,
+            style = HY2Typography().title02,
+            color = Gray100,
+        )
         Spacer(modifier = Modifier.height(2.dp))
         Text(
             text = userInfo.department,
             style = HY2Typography().body05,
             color = Gray100,
         )
+        Spacer(modifier = Modifier.height(8.dp))
+        Box(
+            modifier =
+                Modifier
+                    .size(width = 80.dp, height = 28.dp)
+                    .background(Gray800, shape = RoundedCornerShape(4.dp))
+                    .clip(shape = RoundedCornerShape(4.dp))
+                    .throttleClickable(onClick = onProfileClick),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "프로필 변경",
+                style = HY2Typography().body07,
+                color = Gray200,
+            )
+        }
     }
 }
 

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/components/SettingUserProfile.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/components/SettingUserProfile.kt
@@ -44,10 +44,7 @@ fun SettingUserProfile(
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .throttleClickable(onClick = onProfileClick),
+        modifier = modifier.fillMaxWidth(),
     ) {
         Image(
             painter = profileImagePainter,

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/components/SettingUserProfile.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/components/SettingUserProfile.kt
@@ -1,11 +1,13 @@
 package com.teamhy2.feature.setting.presentation.components
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -14,9 +16,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
-import com.teamhy2.designsystem.ui.theme.Gray200
-import com.teamhy2.designsystem.ui.theme.Gray400
+import com.teamhy2.designsystem.ui.theme.Gray100
 import com.teamhy2.designsystem.ui.theme.HY2Typography
+import com.teamhy2.designsystem.util.modifier.throttleClickable
+import com.teamhy2.hongikyeolgong2.setting.presentation.R
 import com.teamhy2.hongikyeolgong2.setting.presentation.R.drawable.img_settting_profile
 import com.teamhy2.user.domain.model.UserInfo
 
@@ -25,6 +28,7 @@ private const val PROFILE_IMAGE_SIZE = 56
 @Composable
 fun SettingUserProfile(
     userInfo: UserInfo,
+    onProfileClick: () -> Unit,
     modifier: Modifier = Modifier,
     profileImageUrl: String = "",
 ) {
@@ -35,36 +39,34 @@ fun SettingUserProfile(
             painterResource(id = img_settting_profile)
         }
 
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier.fillMaxWidth(),
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier.fillMaxWidth().throttleClickable(onClick = onProfileClick),
     ) {
-        Spacer(modifier = Modifier.width(1.dp))
         Image(
             painter = profileImagePainter,
             contentDescription = null,
             modifier = Modifier.size(PROFILE_IMAGE_SIZE.dp),
         )
-        Spacer(modifier = Modifier.width(20.dp))
-        Row {
+        Spacer(modifier = Modifier.height(12.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
                 text = userInfo.nickname,
-                style = HY2Typography().body05,
-                color = Gray200,
+                style = HY2Typography().title02,
+                color = Gray100,
             )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = "|",
-                style = HY2Typography().body05,
-                color = Gray400,
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = userInfo.department,
-                style = HY2Typography().body05,
-                color = Gray200,
+            Icon(
+                painterResource(id = R.drawable.ic_arrow_right),
+                contentDescription = null,
+                tint = Gray100,
             )
         }
+        Spacer(modifier = Modifier.height(2.dp))
+        Text(
+            text = userInfo.department,
+            style = HY2Typography().body05,
+            color = Gray100,
+        )
     }
 }
 
@@ -77,5 +79,8 @@ private fun SettingUserProfilePreview() {
             email = "urim@gmail.com",
             department = "디자인컨버전스학부",
         )
-    SettingUserProfile(userInfo)
+    SettingUserProfile(
+        userInfo = userInfo,
+        onProfileClick = {},
+    )
 }

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/navigation/SettingNavigation.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/navigation/SettingNavigation.kt
@@ -3,11 +3,18 @@ package com.teamhy2.feature.setting.presentation.navigation
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.teamhy2.feature.setting.presentation.ProfileModificationRoute
 import com.teamhy2.feature.setting.presentation.SettingRoute
 import com.teamhy2.feature.setting.presentation.navigation.Setting.ROUTE
 
 fun NavController.navigateToSetting() {
     navigate(ROUTE)
+}
+
+fun NavController.navigateToProfileModification() {
+    navigate(Setting.PROFILE_MODIFICATION_ROUTE) {
+        launchSingleTop = true
+    }
 }
 
 fun NavGraphBuilder.settingScreen(
@@ -22,8 +29,12 @@ fun NavGraphBuilder.settingScreen(
             onSignOutOrWithdrawComplete = onLogoutOrWithdrawComplete,
         )
     }
+    composable(route = Setting.PROFILE_MODIFICATION_ROUTE) {
+        ProfileModificationRoute()
+    }
 }
 
 object Setting {
     const val ROUTE = "setting"
+    const val PROFILE_MODIFICATION_ROUTE = "profile_modification"
 }

--- a/user-data/src/main/java/com/teamhy2/user/data/repository/RemoteUserRepository.kt
+++ b/user-data/src/main/java/com/teamhy2/user/data/repository/RemoteUserRepository.kt
@@ -2,6 +2,7 @@ package com.teamhy2.user.data.repository
 
 import com.benenfeldt.remote.api.UserPublicService
 import com.benenfeldt.remote.api.UserService
+import com.benenfeldt.remote.dto.UserInfoRequest
 import com.benenfeldt.remote.dto.UserSignInRequest
 import com.benenfeldt.remote.dto.UserSignUpRequest
 import com.benenfeldt.remote.mapper.toResult
@@ -80,5 +81,17 @@ class RemoteUserRepository
         override suspend fun getUserInfo(): Result<UserInfo> {
             return userService.getUserInfo()
                 .toResult { it.data.toDomain() }
+        }
+
+        override suspend fun modifyUserInfo(
+            nickname: String,
+            department: String,
+        ): Result<Unit> {
+            return userService.modifyUserInfo(
+                UserInfoRequest(
+                    nickname = nickname,
+                    department = department,
+                ),
+            ).toResult()
         }
     }

--- a/user-domain/src/main/java/com/teamhy2/user/domain/model/UserInfo.kt
+++ b/user-domain/src/main/java/com/teamhy2/user/domain/model/UserInfo.kt
@@ -4,4 +4,8 @@ data class UserInfo(
     val nickname: String,
     val email: String,
     val department: String,
-)
+) {
+    companion object {
+        val LOADING = UserInfo("불러오는 중..", "불러오는 중..", "불러오는 중..")
+    }
+}

--- a/user-domain/src/main/java/com/teamhy2/user/domain/repository/UserRepository.kt
+++ b/user-domain/src/main/java/com/teamhy2/user/domain/repository/UserRepository.kt
@@ -20,4 +20,9 @@ interface UserRepository {
     suspend fun withdraw(): Result<Unit>
 
     suspend fun getUserInfo(): Result<UserInfo>
+
+    suspend fun modifyUserInfo(
+        nickname: String,
+        department: String,
+    ): Result<Unit>
 }


### PR DESCRIPTION
resolved #160 

## AS-IS
- null

## TO-BE
- Orbit 라이브러리를 사용해서 MVI 패턴을 구현하였습니다.
- NavController를 CompositionLocalProvider로 제공하여 Route 컴포저블에서 사용가능하게 하였습니다.
    - 이렇게 함으로써  Route 컴포저블이 화면이동 관련된 람다 함수를 받을 필요가 없어집니다.
- 폰트 스타일이 추가되었습니다. (body07)

## KEY-POINT
- 라이브러리의 사용으로 ViewModel코드가 매우 간단합니다.

## MVI 패턴 관련 컨벤션 공유
- `State`와 `SideEffect`를 `xxxxContract`라는 파일을 만들어 정의합니다.
```kotlin
// ProfileModificationContract.kt
data class ProfileModificationState(
    val isLoading: Boolean = false,
    val userInfo: UserInfo = UserInfo.LOADING,
    val departments: List<String> = emptyList(),
    val isNicknameValidate: Boolean = false,
    val nicknameState: NicknameState = NicknameState.NOT_CHECKED,
    val isDepartmentValidate: Boolean = false,
)

sealed interface ProfileModificationSideEffect {
    data class ShowError(val throwable: Throwable) : ProfileModificationSideEffect

    data object ProfileModificationSucceed : ProfileModificationSideEffect

    data object ProfileModificationFailure : ProfileModificationSideEffect
}

```
- intent 함수는 축약형으로 식이 본문인 함수로 정의합니다.
```kotlin
// X
private fun checkNicknameValidation() {
    intent {
        reduce {
            state.copy(isNicknameValidate = NicknameValidation.validate(state.userInfo.nickname))
        }
    }
}

// O
private fun checkNicknameValidation() =
    intent {
        reduce {
            state.copy(isNicknameValidate = NicknameValidation.validate(state.userInfo.nickname))
        }
    }
```

## MVI 참고 링크
- [MVI 관련 설명](https://charlezz.com/?p=46365)
- [Oribit 설명](https://charlezz.com/?p=46377)
- [Orbit 공식사이트](https://orbit-mvi.org/)

## SCREENSHOT (Optional)
![Jan-19-2025 20-08-17](https://github.com/user-attachments/assets/0c8b6b4a-0c84-434a-a6aa-500ca63a9a42)
