### PR TITLE
[Feature] 랭킹 아이템 색상 지정 로직 변경 및 1월 1주차에서 전주차로 이동 방지 로직 추가

### DIFF
--- a/ranking-data/src/main/java/com/teamhy2/ranking/data/repository/RemoteRankingRepository.kt
+++ b/ranking-data/src/main/java/com/teamhy2/ranking/data/repository/RemoteRankingRepository.kt
@@ -25,7 +25,7 @@ class RemoteRankingRepository
         override suspend fun fetchRanking(weekNumber: Int): Result<Ranking> {
             return studyService.getRanking(weekNumber).toResult { baseResponse ->
                 baseResponse.data.toDomain().copy(
-                    departmentRankings = baseResponse.data.toDomain().departmentRankings.sortedBy { it.currentRank },
+                    departmentRankings = baseResponse.data.toDomain().departmentRankings,
                 )
             }
         }

--- a/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingViewModel.kt
+++ b/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingViewModel.kt
@@ -36,9 +36,9 @@ class RankingViewModel
             getWeekNumber()
         }
 
-        private fun getWeekNumber() {
+        private fun getWeekNumber(date: LocalDate = LocalDate.now()) {
             viewModelScope.launch {
-                rankingRepository.fetchWeekNumber(LocalDate.now())
+                rankingRepository.fetchWeekNumber(date)
                     .onSuccess { weekNumber ->
                         currentWeekNumber = weekNumber.weekNumber
                         latestWeekNumber = weekNumber.weekNumber
@@ -70,6 +70,11 @@ class RankingViewModel
 
         fun getLastWeekRanking() {
             currentWeekNumber?.let { currentWeekNumber ->
+                val week = currentWeekNumber % 100
+                if (week == 1) {
+                    return
+                }
+
                 getDepartmentRankings(currentWeekNumber - 1)
             }
         }

--- a/ranking-presentation/src/main/java/com/teamhy2/ranking/components/RankingItem.kt
+++ b/ranking-presentation/src/main/java/com/teamhy2/ranking/components/RankingItem.kt
@@ -29,6 +29,7 @@ import com.teamhy2.designsystem.ui.theme.Gray600
 import com.teamhy2.designsystem.ui.theme.Gray800
 import com.teamhy2.designsystem.ui.theme.HY2Typography
 import com.teamhy2.designsystem.ui.theme.White
+import com.teamhy2.hongikyeolgong2.ranking.presentation.R
 import com.teamhy2.hongikyeolgong2.ranking.presentation.R.drawable.ic_ranking_dash
 import com.teamhy2.hongikyeolgong2.ranking.presentation.R.drawable.ic_ranking_down
 import com.teamhy2.hongikyeolgong2.ranking.presentation.R.drawable.ic_ranking_up
@@ -106,7 +107,7 @@ fun RankingItem(
                 },
     ) {
         Text(
-            text = "$rank",
+            text = if (rank == 0) "-" else "$rank",
             style = HY2Typography().body05,
             color = rankItemStyle.textColor,
         )
@@ -127,17 +128,25 @@ fun RankingItem(
             horizontalArrangement = Arrangement.End,
             modifier = Modifier.width(50.dp),
         ) {
-            Text(
-                text = rankChangeText,
-                style = HY2Typography().caption,
-                color = rankItemStyle.textColor,
-            )
-            Spacer(modifier = Modifier.width(7.dp))
-            Image(
-                painter = painterResource(id = rankChangeIcon),
-                contentDescription = null,
-                modifier = Modifier.size(10.dp),
-            )
+            if (rank != 0) {
+                Text(
+                    text = rankChangeText,
+                    style = HY2Typography().caption,
+                    color = rankItemStyle.textColor,
+                )
+                Spacer(modifier = Modifier.width(7.dp))
+                Image(
+                    painter = painterResource(id = rankChangeIcon),
+                    contentDescription = null,
+                    modifier = Modifier.size(10.dp),
+                )
+            } else {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_ranking_dash),
+                    contentDescription = null,
+                    modifier = Modifier.size(10.dp),
+                )
+            }
         }
     }
 }

--- a/ranking-presentation/src/main/java/com/teamhy2/ranking/components/RankingItem.kt
+++ b/ranking-presentation/src/main/java/com/teamhy2/ranking/components/RankingItem.kt
@@ -29,7 +29,6 @@ import com.teamhy2.designsystem.ui.theme.Gray600
 import com.teamhy2.designsystem.ui.theme.Gray800
 import com.teamhy2.designsystem.ui.theme.HY2Typography
 import com.teamhy2.designsystem.ui.theme.White
-import com.teamhy2.hongikyeolgong2.ranking.presentation.R
 import com.teamhy2.hongikyeolgong2.ranking.presentation.R.drawable.ic_ranking_dash
 import com.teamhy2.hongikyeolgong2.ranking.presentation.R.drawable.ic_ranking_down
 import com.teamhy2.hongikyeolgong2.ranking.presentation.R.drawable.ic_ranking_up
@@ -77,7 +76,14 @@ fun RankingItem(
             else -> ic_ranking_dash
         }
 
-    val rankChangeText =
+    val rankText: String =
+        if (rank == 0) {
+            "-"
+        } else {
+            "$rank"
+        }
+
+    val rankChangeText: String =
         if (rankChange > 0) {
             "+$rankChange"
         } else if (rankChange < 0) {
@@ -107,7 +113,7 @@ fun RankingItem(
                 },
     ) {
         Text(
-            text = if (rank == 0) "-" else "$rank",
+            text = rankText,
             style = HY2Typography().body05,
             color = rankItemStyle.textColor,
         )
@@ -128,25 +134,17 @@ fun RankingItem(
             horizontalArrangement = Arrangement.End,
             modifier = Modifier.width(50.dp),
         ) {
-            if (rank != 0) {
-                Text(
-                    text = rankChangeText,
-                    style = HY2Typography().caption,
-                    color = rankItemStyle.textColor,
-                )
-                Spacer(modifier = Modifier.width(7.dp))
-                Image(
-                    painter = painterResource(id = rankChangeIcon),
-                    contentDescription = null,
-                    modifier = Modifier.size(10.dp),
-                )
-            } else {
-                Image(
-                    painter = painterResource(id = R.drawable.ic_ranking_dash),
-                    contentDescription = null,
-                    modifier = Modifier.size(10.dp),
-                )
-            }
+            Text(
+                text = rankChangeText,
+                style = HY2Typography().caption,
+                color = rankItemStyle.textColor,
+            )
+            Spacer(modifier = Modifier.width(7.dp))
+            Image(
+                painter = painterResource(id = rankChangeIcon),
+                contentDescription = null,
+                modifier = Modifier.size(10.dp),
+            )
         }
     }
 }


### PR DESCRIPTION
resolved #161 

## AS-IS
-기존 랭킹을 서버에서 내려주는 방식은 랭킹 순위와 상관없이 내려주면 클라이언트에서 sorting하여 1,2,3위 색상을 지정 하고 나머지는 같은 색으로 표현하였습니다.
- 순위를 0으로 내려준다면 0이 그대로 순위에 표기되었습니다.

## TO-BE
- 이제는 서버에서 랭킹 순위에 따라 정렬하여 내려주어 클라이언트에서 자체 sorting하는 로직을 제거하였습니다. 
- 순위가 0으로 넘어온다면 "-"로 변경하는 로직를 추가하였습니다.
- 2025년도 1주차에서 2024년도 마지막 주차로 이동하려고 한다면 iOS 구현과 동일하게 이동하지 못하도록 방지하였습니다.

## KEY-POINT
- `getWeekNumber`는 현재 오늘의 `weekNumber`를 가지고 오는 로직을 가지고 있는데 함수 이름만 보고`getWeekNumber`가 `오늘의` `weekNumber`를 가져오는 것을 알 수 없을 것 같아 파라미터를 추가하고 기본값으로 `LocalDate.now()`를 추가하여 기존 로직과 동일하게 돌아가도록 수정하였습니다.

- 2025년도 1주차에서 2024년도 마지막 주차로 이동하는 로직은 추가 의논이 필요할 것 같습니다.

## SCREENSHOT (Optional)
