### PR TITLE
[Feature] 랭킹 조회를 위한 WeekNumberCalculator 구현

### DIFF
--- a/ranking-domain/src/main/java/com/teamhy2/ranking/WeekNumberCalculator.kt
+++ b/ranking-domain/src/main/java/com/teamhy2/ranking/WeekNumberCalculator.kt
@@ -1,0 +1,43 @@
+package com.teamhy2.ranking
+
+import java.time.LocalDate
+import java.time.temporal.WeekFields
+
+object WeekNumberCalculator {
+    /**
+     * 주어진 날짜에 대해 weekNumber를 계산한다.
+     *
+     * weekNumber 기준:
+     * - 주는 월요일~일요일 단위.
+     * - 해당 달의 최소 4일 포함 되어야 하는 기준 ISO 방식을 따른다.
+     * - 해당 주의 weekNumber는, 지정 연도(weekBasedYear)의 첫 주(ISO 기준)부터 몇 번째 주인지를 의미한다.
+     *
+     * 반환 형식: year * 100 + weekIndex
+     * 예) 2025년 9번째 주 → 202509
+     */
+    fun calculateWeekNumber(date: LocalDate): Int {
+        val weekFields: WeekFields = WeekFields.ISO
+        val weekOfYear: Int = date.get(weekFields.weekOfWeekBasedYear())
+        val year: Int = date.get(weekFields.weekBasedYear())
+        return year * 100 + weekOfYear
+    }
+
+    fun shiftWeekNumber(
+        weekNumber: Int,
+        offset: Int,
+    ): Int {
+        val weekFields: WeekFields = WeekFields.ISO
+        val year: Int = weekNumber / 100
+        val weekOfYear: Int = weekNumber % 100
+
+        val firstWeekMondayOfYear: LocalDate =
+            LocalDate.of(year, 1, 1)
+                .with(weekFields.dayOfWeek(), 1L)
+
+        val currentWeekMonday: LocalDate = firstWeekMondayOfYear.plusWeeks((weekOfYear - 1).toLong())
+
+        val newWeekMonday: LocalDate = currentWeekMonday.plusWeeks(offset.toLong())
+
+        return calculateWeekNumber(newWeekMonday)
+    }
+}

--- a/ranking-domain/src/test/kotlin/com/teamhy2/ranking/WeekNumberCalculatorTest.kt
+++ b/ranking-domain/src/test/kotlin/com/teamhy2/ranking/WeekNumberCalculatorTest.kt
@@ -1,0 +1,61 @@
+package com.teamhy2.ranking
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+
+class WeekNumberCalculatorTest : BehaviorSpec({
+    Given("날짜(LocalDate)가 주어지면 weekNumber를 계산할 수 있다") {
+        When("날짜가 2025년 1월 6일(월요일)인 경우") {
+            val date: LocalDate = LocalDate.of(2025, 1, 6)
+            val weekNumber: Int = WeekNumberCalculator.calculateWeekNumber(date)
+
+            Then("주 번호는 202502가 되어야 한다") {
+                weekNumber shouldBe 202502
+            }
+        }
+
+        When("날짜가 2025년 12월 31일(수요일)인 경우") {
+            val date: LocalDate = LocalDate.of(2025, 12, 31)
+            val weekNumber: Int = WeekNumberCalculator.calculateWeekNumber(date)
+
+            Then("주 번호는 202601이 되어야 한다") {
+                weekNumber shouldBe 202601
+            }
+        }
+    }
+
+    Given("현재 weekNumber를 기반으로 다음주 or 저번주 weekNumber를 계산할 수 있다") {
+        When("202502에서 +1 주 이동하면") {
+            val shiftedWeek: Int = WeekNumberCalculator.shiftWeekNumber(202502, 1)
+
+            Then("202503이 되어야 한다") {
+                shiftedWeek shouldBe 202503
+            }
+        }
+
+        When("202502에서 -1 주 이동하면") {
+            val shiftedWeek: Int = WeekNumberCalculator.shiftWeekNumber(202502, -1)
+
+            Then("202501이 되어야 한다") {
+                shiftedWeek shouldBe 202501
+            }
+        }
+
+        When("202501에서 -1 주 이동하면") {
+            val shiftedWeek: Int = WeekNumberCalculator.shiftWeekNumber(202501, -1)
+
+            Then("2024년의 마지막 주, 즉 202452가 되어야 한다") {
+                shiftedWeek shouldBe 202452
+            }
+        }
+
+        When("202452에서 +1 주 이동하면") {
+            val shiftedWeek: Int = WeekNumberCalculator.shiftWeekNumber(202452, 1)
+
+            Then("2025년의 첫 주, 즉 202501이 되어야 한다") {
+                shiftedWeek shouldBe 202501
+            }
+        }
+    }
+})

--- a/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingContract.kt
+++ b/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingContract.kt
@@ -6,6 +6,7 @@ data class RankingState(
     val isLoading: Boolean = false,
     val currentWeek: String = "",
     val departmentRankings: List<DepartmentRanking> = emptyList(),
+    val isNextWeekEnabled: Boolean = false,
 )
 
 sealed interface RankingSideEffect {

--- a/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingScreen.kt
+++ b/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -27,6 +28,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.teamhy2.designsystem.common.HY2CircularLoading
 import com.teamhy2.designsystem.ui.theme.BackgroundBlack
 import com.teamhy2.designsystem.ui.theme.Gray100
+import com.teamhy2.designsystem.ui.theme.Gray800
 import com.teamhy2.designsystem.ui.theme.HY2Typography
 import com.teamhy2.designsystem.util.compositionlocal.LocalShowSnackBar
 import com.teamhy2.designsystem.util.compositionlocal.LocalTracker
@@ -65,6 +67,7 @@ fun RankingRoute(
             RankingScreen(
                 currentWeek = state.currentWeek,
                 departmentRankings = state.departmentRankings.toImmutableList(),
+                isNextWeekEnabled = state.isNextWeekEnabled,
                 onLastWeekClick = { rankingViewModel.getLastWeekRanking() },
                 onNextWeekClick = { rankingViewModel.getNextWeekRanking() },
                 modifier =
@@ -80,6 +83,7 @@ fun RankingRoute(
 fun RankingScreen(
     currentWeek: String,
     departmentRankings: ImmutableList<DepartmentRanking>,
+    isNextWeekEnabled: Boolean,
     onLastWeekClick: () -> Unit,
     onNextWeekClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -91,6 +95,7 @@ fun RankingScreen(
             currentWeek = currentWeek,
             onLastWeekClick = onLastWeekClick,
             onNextWeekClick = onNextWeekClick,
+            isNextWeekEnabled = isNextWeekEnabled,
         )
         Spacer(modifier = Modifier.height(20.dp))
         RankingBody(
@@ -102,6 +107,7 @@ fun RankingScreen(
 @Composable
 fun RankingHeader(
     currentWeek: String,
+    isNextWeekEnabled: Boolean,
     onLastWeekClick: () -> Unit,
     onNextWeekClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -121,10 +127,14 @@ fun RankingHeader(
                 contentDescription = null,
             )
         }
-        IconButton(onClick = onNextWeekClick) {
+        IconButton(
+            onClick = onNextWeekClick,
+            enabled = isNextWeekEnabled,
+        ) {
             Image(
                 painter = painterResource(id = R.drawable.ic_ranking_next_week),
                 contentDescription = null,
+                colorFilter = if (isNextWeekEnabled.not()) ColorFilter.tint(Gray800) else null,
             )
         }
     }
@@ -224,5 +234,6 @@ fun RankingScreenPreview() {
         departmentRankings = sampleDepartmentRankings,
         onLastWeekClick = {},
         onNextWeekClick = {},
+        isNextWeekEnabled = true,
     )
 }

--- a/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingScreen.kt
+++ b/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.teamhy2.designsystem.common.HY2CircularLoading
+import com.teamhy2.designsystem.common.HY2LoadingScreen
 import com.teamhy2.designsystem.ui.theme.BackgroundBlack
 import com.teamhy2.designsystem.ui.theme.Gray100
 import com.teamhy2.designsystem.ui.theme.Gray800
@@ -61,26 +61,24 @@ fun RankingRoute(
         tracker.trackEvent("Ranking")
     }
 
-    when (state.isLoading) {
-        true -> HY2CircularLoading()
-        false ->
-            RankingScreen(
-                currentWeek = state.currentWeek,
-                departmentRankings = state.departmentRankings.toImmutableList(),
-                isNextWeekEnabled = state.isNextWeekEnabled,
-                onLastWeekClick = { rankingViewModel.getLastWeekRanking() },
-                onNextWeekClick = { rankingViewModel.getNextWeekRanking() },
-                modifier =
-                    modifier
-                        .background(BackgroundBlack)
-                        .padding(horizontal = 24.dp)
-                        .fillMaxSize(),
-            )
-    }
+    RankingScreen(
+        isLoading = state.isLoading,
+        currentWeek = state.currentWeek,
+        departmentRankings = state.departmentRankings.toImmutableList(),
+        isNextWeekEnabled = state.isNextWeekEnabled,
+        onLastWeekClick = { rankingViewModel.getLastWeekRanking() },
+        onNextWeekClick = { rankingViewModel.getNextWeekRanking() },
+        modifier =
+            modifier
+                .background(BackgroundBlack)
+                .padding(horizontal = 24.dp)
+                .fillMaxSize(),
+    )
 }
 
 @Composable
 fun RankingScreen(
+    isLoading: Boolean,
     currentWeek: String,
     departmentRankings: ImmutableList<DepartmentRanking>,
     isNextWeekEnabled: Boolean,
@@ -98,9 +96,10 @@ fun RankingScreen(
             isNextWeekEnabled = isNextWeekEnabled,
         )
         Spacer(modifier = Modifier.height(20.dp))
-        RankingBody(
-            departmentRankings = departmentRankings,
-        )
+        when (isLoading) {
+            true -> HY2LoadingScreen()
+            false -> RankingBody(departmentRankings = departmentRankings)
+        }
     }
 }
 
@@ -230,6 +229,7 @@ fun RankingScreenPreview() {
         ).toImmutableList()
 
     RankingScreen(
+        isLoading = false,
         currentWeek = "9월 1주차",
         departmentRankings = sampleDepartmentRankings,
         onLastWeekClick = {},

--- a/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingViewModel.kt
+++ b/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingViewModel.kt
@@ -15,29 +15,16 @@ class RankingViewModel
     constructor(
         private val rankingRepository: RankingRepository,
     ) : ViewModel(), ContainerHost<RankingState, RankingSideEffect> {
-        override val container: Container<RankingState, RankingSideEffect> = container(RankingState())
+        override val container: Container<RankingState, RankingSideEffect> =
+            container(RankingState())
 
-        private var currentWeekNumber: Int? = null
-        private var latestWeekNumber: Int? = null
+        private var currentWeekNumber: Int =
+            WeekNumberCalculator.calculateWeekNumber(LocalDate.now())
+        private val latestWeekNumber: Int = currentWeekNumber
 
         init {
-            getWeekNumber()
+            getDepartmentRankings(currentWeekNumber)
         }
-
-        private fun getWeekNumber(date: LocalDate = LocalDate.now()) =
-            intent {
-                reduce { state.copy(isLoading = true) }
-                rankingRepository.fetchWeekNumber(date)
-                    .onSuccess { weekNumber ->
-                        currentWeekNumber = weekNumber.weekNumber
-                        latestWeekNumber = weekNumber.weekNumber
-                        getDepartmentRankings(weekNumber.weekNumber)
-                    }
-                    .onFailure { throwable ->
-                        reduce { state.copy(isLoading = false) }
-                        postSideEffect(RankingSideEffect.ShowError(throwable))
-                    }
-            }
 
         private fun getDepartmentRankings(weekNumber: Int) =
             intent {
@@ -50,6 +37,7 @@ class RankingViewModel
                                 isLoading = false,
                                 currentWeek = ranking.weekName,
                                 departmentRankings = ranking.departmentRankings,
+                                isNextWeekEnabled = currentWeekNumber < latestWeekNumber,
                             )
                         }
                     }
@@ -60,19 +48,13 @@ class RankingViewModel
             }
 
         fun getLastWeekRanking() {
-            currentWeekNumber?.let { currentWeekNumber ->
-                val week: Int = currentWeekNumber % 100
-                if (week == 1) return
-
-                getDepartmentRankings(currentWeekNumber - 1)
-            }
+            val lastWeekNumber: Int = WeekNumberCalculator.shiftWeekNumber(currentWeekNumber, -1)
+            getDepartmentRankings(lastWeekNumber)
         }
 
         fun getNextWeekRanking() {
-            currentWeekNumber?.let { currentWeekNumber ->
-                if (currentWeekNumber >= (latestWeekNumber ?: currentWeekNumber)) return
-
-                getDepartmentRankings(currentWeekNumber + 1)
-            }
+            if (currentWeekNumber >= latestWeekNumber) return
+            val nextWeekNumber = WeekNumberCalculator.shiftWeekNumber(currentWeekNumber, 1)
+            getDepartmentRankings(nextWeekNumber)
         }
     }


### PR DESCRIPTION
resolved #174 

## AS-IS
기존 랭킹을 불러오는 로직은 아래와 같습니다.
1. 오늘날짜를 서버에 보내 `weekNumber`를 받는다
2. `weekNumber`를 서버에 보내 랭킹 정보를 받는다
3. 저번주 혹은 다음주로 이동한다면  `weekNumber`에 +-1 를 해주어 이동한다.

해당 로직에는 2가지 문제점이 있습니다.
1. 예를 들어 25년도 1번째 주차에서 지난주로 이동한다면 24년도 마지막 주차로 넘어갈 때 1년에는 52주 혹은 53주이기 때문에 어떤 값이 옳은지 알 수 없습니다. 현재 로직은 그저 +- 1만 하는 로직이기 때문입니다.
2. 24년도 마지막 주차에서 25년도 첫번째 주차로 넘어가는 것도 현재 주차가 마지막 주차인지 인식할 수 없기 때문에 넘어갈 수 없습니다.
3. 불필요한 API 통신이 발생한다 최초 랭킹을 가져오는데 최소 2회 API 통신 필요

## TO-BE
- 문제 해결을 위해 `weekNumber`를 계산하는 `WeekNumberCalculator`를 구현하였습니다.
- 랭킹에서 중요한 도메인 로직이라고 판단하여 domain에 구현하였고 `WeekNumberCalculator` Test 코드도 작성하였습니다.
- 현재 주차가 최신 주차라면 다음주로 넘어가는 버튼을 비활성화하고 색상을 변경하는 기능을 추가하였습니다.

### WeekNumberCalculator

weekNumber를 구분하는 기준(ISO기준)은 아래와 같습니다.
- 주는 월요일~일요일 단위.
- 해당 달의 최소 4일 포함 되어야 합니다. 
  - 예를 들어 아래 사진같이25년 12월 31일은 12월이 3일 밖에 속하지 않았기 때문에 26년도 1주차에 포함됩니다. (테스트 코드에 존재합니다)
<img width="841" alt="스크린샷 2025-02-27 오후 5 38 13" src="https://github.com/user-attachments/assets/e624f394-0d65-4550-bfc9-1d11f975ebb2" />
- 해당 주의 weekNumber는, 지정 연도(weekBasedYear)의 첫 주(ISO 기준)부터 몇 번째 주인지를 의미합니다.

예상 문제점
- 서버가 주차를 계산하는 로직이 달라진다면 클라이언트도 같이 변경을 해주어야 합니다.

## KEY-POINT
- 궁금한점은 언제든 질문 주세요!

## SCREENSHOT (Optional)

https://github.com/user-attachments/assets/fc570709-47d9-4975-a767-ff3a92d493a3

