### PR TITLE
[Performance, Fix]  KAPT -> KSP로 마이그레이션 합니다.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="${appIcon}"
         android:label="@string/app_name"
-        android:largeHeap="true"
         android:roundIcon="${roundIcon}"
         android:supportsRtl="true"
         android:theme="@style/Theme.HongikYeolgong2"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="${appIcon}"
         android:label="@string/app_name"
+        android:largeHeap="true"
         android:roundIcon="${roundIcon}"
         android:supportsRtl="true"
         android:theme="@style/Theme.HongikYeolgong2"
@@ -22,7 +23,7 @@
         <service
             android:name=".timer.presentation.TimerForegroundService"
             android:exported="false"
-            android:foregroundServiceType="dataSync"/>
+            android:foregroundServiceType="dataSync" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/build-logic/src/main/java/com/teamhy2/app/HiltAndroid.kt
+++ b/build-logic/src/main/java/com/teamhy2/app/HiltAndroid.kt
@@ -7,14 +7,14 @@ import org.gradle.kotlin.dsl.dependencies
 internal fun Project.configureHiltAndroid() {
 	with(pluginManager) {
 		apply("dagger.hilt.android.plugin")
-		apply("org.jetbrains.kotlin.kapt")
+		apply("com.google.devtools.ksp")
 	}
 
 	val libs = extensions.libs
 	dependencies {
 		"implementation"(libs.findLibrary("hilt.android").get())
-		"kapt"(libs.findLibrary("hilt.android.compiler").get())
-		"kaptAndroidTest"(libs.findLibrary("hilt.android.compiler").get())
+		"ksp"(libs.findLibrary("hilt.android.compiler").get())
+		"kspAndroidTest"(libs.findLibrary("hilt.android.compiler").get())
 	}
 }
 

--- a/build-logic/src/main/java/com/teamhy2/app/HiltKotlin.kt
+++ b/build-logic/src/main/java/com/teamhy2/app/HiltKotlin.kt
@@ -6,13 +6,13 @@ import org.gradle.kotlin.dsl.dependencies
 
 internal fun Project.configureHiltKotlin() {
 	with(pluginManager) {
-		apply("org.jetbrains.kotlin.kapt")
+		apply("com.google.devtools.ksp")
 	}
 
 	val libs = extensions.libs
 	dependencies {
 		"implementation"(libs.findLibrary("hilt.core").get())
-		"kapt"(libs.findLibrary("hilt.compiler").get())
+		"ksp"(libs.findLibrary("hilt.compiler").get())
 	}
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.jetbrains.kotlin.jvm) apply false
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.google.firebase.crashlytics) apply false
+    alias(libs.plugins.ksp) apply false
 }
 
 allprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,17 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath(libs.oss.licenses.plugin)
+    }
+    gradle.startParameter.excludedTaskNames.addAll(
+        gradle.startParameter.taskNames.filter { it.contains("testClasses") },
+    )
+}
+
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false

--- a/core/auth/build.gradle.kts
+++ b/core/auth/build.gradle.kts
@@ -2,7 +2,6 @@ import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 
 plugins {
     id("hongikyeolgong2.android.feature")
-    alias(libs.plugins.google.services)
 }
 
 android {

--- a/core/remote/build.gradle.kts
+++ b/core/remote/build.gradle.kts
@@ -3,7 +3,6 @@ import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 plugins {
     id("hongikyeolgong2.android.library")
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.google.services)
 }
 
 android {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ accompanistPermissions = "0.31.1-alpha"
 agp = "8.3.2"
 firebaseBom = "33.1.2"
 kotlin = "1.9.0"
+ksp = "1.9.0-1.0.13"
 coreKtx = "1.13.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"
@@ -23,8 +24,8 @@ kotest = "5.6.2"
 coroutine = "1.7.2"
 androidxComposeNavigation = "2.7.0"
 androidxLifecycle = "2.6.1"
-hilt = "2.46.1"
-hiltNavigationCompose = "1.0.0"
+hilt = "2.49"
+hiltNavigationCompose = "1.2.0"
 activity = "1.9.0"
 constraintlayout = "2.1.4"
 navigationFragmentKtx = "2.7.7"
@@ -168,3 +169,4 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 google-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "googleFirebaseCrashlytics" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,10 @@ firebaseConfigKtx = "22.0.1"
 orbit = "9.0.0"
 navigationRuntimeKtx = "2.8.5"
 
+## license
+ossLicenses = "17.1.0"
+ossLicensesPlugin = "0.10.6"
+
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -158,6 +162,9 @@ orbit-viewmodel = { module = "org.orbit-mvi:orbit-viewmodel", version.ref = "orb
 
 # Immutable-collection
 kotlinx-immutable-collection = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxImmutable" }
+
+oss-licenses = { group = "com.google.android.gms", name = "play-services-oss-licenses", version.ref = "ossLicenses" }
+oss-licenses-plugin = { group = "com.google.android.gms", name = "oss-licenses-plugin", version.ref = "ossLicensesPlugin" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
resolved #106 

## AS-IS
- KAPT 플러그인을 사용
- 빌드 오류 발생

## TO-BE
- KSP로 마이그레이션
- 빌드 에러 수정

## KEY-POINT
- 23년 8월 부로 Dagger에서 KSP를 지원하기 시작 하였고,
- 지금 현재 KSP를 지원하지 않는 라이브러리는 Databinding 정도 있습니다.
- 만약 Databinding을 위해 KAPT와 KSP를 혼용하면 KSP의 성능적 이점을 온전히 누릴 수 없습니다.
- 아시다시피 100% 컴포즈 프로젝트기에 과감하게 마이그레이션 합니다!

## SCREENSHOT (Optional)

### 캐시 지우고 리빌드 속도 [단 6초]

<img width="1150" alt="image" src="https://github.com/user-attachments/assets/6654ef7f-1ea6-4133-b747-89a67831692d" />

