### PR TITLE
[Feature] FCM을 통해 진입했다면 Amplitude에 로깅한다

### DIFF
--- a/main-presentation/src/main/java/com/teamhy2/feature/main/MainActivity.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/MainActivity.kt
@@ -75,6 +75,8 @@ class MainActivity : AppCompatActivity() {
         val versionCode: Long = packageManager.getPackageInfo(packageName, 0).longVersionCode
         initialViewModel.getMinVersion(versionCode)
 
+        checkLaunchedWithFcm()
+
         enableEdgeToEdge()
 
         setContent {
@@ -175,6 +177,13 @@ class MainActivity : AppCompatActivity() {
                     }
                 }
             }
+        }
+    }
+
+    private fun checkLaunchedWithFcm() {
+        val fromFcm = intent.extras?.get("google.message_id") != null
+        if (fromFcm) {
+            tracker.trackEvent("Push Noti")
         }
     }
 

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/MainActivity.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/MainActivity.kt
@@ -75,7 +75,7 @@ class MainActivity : AppCompatActivity() {
         val versionCode: Long = packageManager.getPackageInfo(packageName, 0).longVersionCode
         initialViewModel.getMinVersion(versionCode)
 
-        checkLaunchedWithFcm()
+        checkLaunchedFromFcm()
 
         enableEdgeToEdge()
 
@@ -180,7 +180,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun checkLaunchedWithFcm() {
+    private fun checkLaunchedFromFcm() {
         val fromFcm = intent.extras?.get("google.message_id") != null
         if (fromFcm) {
             tracker.trackEvent("Push Noti")


### PR DESCRIPTION
resolved #182 

## AS-IS
null

## TO-BE
FCM 알림 클릭으로 메인액티비티 진입 시 앰플리튜드에 로깅한다.

## KEY-POINT
```json
{
  "to": "<FCM_TOKEN>",
  "notification": {
    "title": "제목",
    "body": "본문"
  }
}
```

현재 이런식으로 notification이 오는데 이럴 경우 알림 클릭시 기본 설정으로 FCM이 앱의 런처 액티비티를 켜줍니다.
그때의 인텐트에 들어있는 extra 값을 통해 FCM을 통한 진입임을 걸러내고 Amplitude에 로깅하는 원리입니다.