### PR TITLE
[Refactor] 온보딩 화면을 MVI 리펙토링

### DIFF
--- a/onboarding-presentation/src/main/java/com/teamhy2/onboarding/OnboardingContract.kt
+++ b/onboarding-presentation/src/main/java/com/teamhy2/onboarding/OnboardingContract.kt
@@ -5,9 +5,7 @@ data object OnboardingState
 sealed interface OnboardingSideEffect {
     data class ShowError(val errorMessage: String?) : OnboardingSideEffect
 
-    sealed interface Navigation : OnboardingSideEffect {
-        data object SignIn : Navigation
+    data object NavigateToSignIn : OnboardingSideEffect
 
-        data object Home : Navigation
-    }
+    data object NavigateToHome : OnboardingSideEffect
 }

--- a/onboarding-presentation/src/main/java/com/teamhy2/onboarding/OnboardingContract.kt
+++ b/onboarding-presentation/src/main/java/com/teamhy2/onboarding/OnboardingContract.kt
@@ -1,0 +1,13 @@
+package com.teamhy2.onboarding
+
+data object OnboardingState
+
+sealed interface OnboardingSideEffect {
+    data class ShowError(val errorMessage: String) : OnboardingSideEffect
+
+    sealed interface Navigation : OnboardingSideEffect {
+        data object SignIn : Navigation
+
+        data object Home : Navigation
+    }
+}

--- a/onboarding-presentation/src/main/java/com/teamhy2/onboarding/OnboardingContract.kt
+++ b/onboarding-presentation/src/main/java/com/teamhy2/onboarding/OnboardingContract.kt
@@ -3,7 +3,7 @@ package com.teamhy2.onboarding
 data object OnboardingState
 
 sealed interface OnboardingSideEffect {
-    data class ShowError(val errorMessage: String) : OnboardingSideEffect
+    data class ShowError(val errorMessage: String?) : OnboardingSideEffect
 
     sealed interface Navigation : OnboardingSideEffect {
         data object SignIn : Navigation

--- a/onboarding-presentation/src/main/java/com/teamhy2/onboarding/OnboardingScreen.kt
+++ b/onboarding-presentation/src/main/java/com/teamhy2/onboarding/OnboardingScreen.kt
@@ -17,8 +17,6 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,7 +28,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.teamhy2.core.auth.GoogleSignIn
 import com.teamhy2.core.auth.GoogleSignInButton
 import com.teamhy2.designsystem.ui.theme.BackgroundBlack
@@ -38,7 +35,7 @@ import com.teamhy2.designsystem.ui.theme.Gray600
 import com.teamhy2.designsystem.ui.theme.HY2Theme
 import com.teamhy2.designsystem.util.compositionlocal.LocalShowSnackBar
 import com.teamhy2.onboarding.presentation.R
-import kotlinx.coroutines.flow.collectLatest
+import org.orbitmvi.orbit.compose.collectSideEffect
 
 @Composable
 fun OnboardingRoute(
@@ -47,22 +44,17 @@ fun OnboardingRoute(
     modifier: Modifier = Modifier,
     onboardingViewModel: OnboardingViewModel = hiltViewModel(),
 ) {
-    val signInState by onboardingViewModel.signInState.collectAsStateWithLifecycle()
-
-    if (signInState == SignInState.SuccessfulSignedInGuest) {
-        onGuestSignedIn()
-    }
-    if (signInState == SignInState.SuccessfulSignedInUser) {
-        onUserSignedIn()
-    }
-
     val localShowSnackBar = LocalShowSnackBar.current
     val context = LocalContext.current
     val googleSignIn: GoogleSignIn = remember { GoogleSignIn(context) }
 
-    LaunchedEffect(true) {
-        onboardingViewModel.errorFlow.collectLatest { throwable ->
-            localShowSnackBar.showSnackBar(throwable.message)
+    onboardingViewModel.collectSideEffect {
+        when (it) {
+            is OnboardingSideEffect.Navigation.Home -> onUserSignedIn()
+            is OnboardingSideEffect.Navigation.SignIn -> onGuestSignedIn()
+            is OnboardingSideEffect.ShowError -> {
+                localShowSnackBar.showSnackBar(it.errorMessage)
+            }
         }
     }
 

--- a/onboarding-presentation/src/main/java/com/teamhy2/onboarding/OnboardingScreen.kt
+++ b/onboarding-presentation/src/main/java/com/teamhy2/onboarding/OnboardingScreen.kt
@@ -50,10 +50,16 @@ fun OnboardingRoute(
 
     onboardingViewModel.collectSideEffect {
         when (it) {
-            is OnboardingSideEffect.Navigation.Home -> onUserSignedIn()
-            is OnboardingSideEffect.Navigation.SignIn -> onGuestSignedIn()
             is OnboardingSideEffect.ShowError -> {
                 localShowSnackBar.showSnackBar(it.errorMessage)
+            }
+
+            OnboardingSideEffect.NavigateToHome -> {
+                onUserSignedIn()
+            }
+
+            OnboardingSideEffect.NavigateToSignIn -> {
+                onGuestSignedIn()
             }
         }
     }

--- a/onboarding-presentation/src/main/java/com/teamhy2/onboarding/OnboardingViewModel.kt
+++ b/onboarding-presentation/src/main/java/com/teamhy2/onboarding/OnboardingViewModel.kt
@@ -36,8 +36,8 @@ class OnboardingViewModel
                 userRepository.signIn(idToken)
                     .onSuccess { isAlreadyExist ->
                         when (isAlreadyExist) {
-                            true -> postSideEffect(OnboardingSideEffect.Navigation.Home)
-                            false -> postSideEffect(OnboardingSideEffect.Navigation.SignIn)
+                            true -> postSideEffect(OnboardingSideEffect.NavigateToHome)
+                            false -> postSideEffect(OnboardingSideEffect.NavigateToSignIn)
                         }
                     }
                     .onFailure { throwable ->

--- a/onboarding-presentation/src/main/java/com/teamhy2/onboarding/OnboardingViewModel.kt
+++ b/onboarding-presentation/src/main/java/com/teamhy2/onboarding/OnboardingViewModel.kt
@@ -1,18 +1,12 @@
 package com.teamhy2.onboarding
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.teamhy2.core.auth.GoogleSignIn
 import com.teamhy2.user.domain.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.Container
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.viewmodel.container
 import javax.inject.Inject
 
 @HiltViewModel
@@ -20,38 +14,40 @@ class OnboardingViewModel
     @Inject
     constructor(
         private val userRepository: UserRepository,
-    ) : ViewModel() {
-        private val _signInState: MutableStateFlow<SignInState> = MutableStateFlow(SignInState.Idle)
-        val signInState: StateFlow<SignInState> = _signInState.asStateFlow()
+    ) : ViewModel(), ContainerHost<OnboardingState, OnboardingSideEffect> {
+        override val container: Container<OnboardingState, OnboardingSideEffect> =
+            container(OnboardingState)
 
-        private val _errorFlow = MutableSharedFlow<Throwable>()
-        val errorFlow: SharedFlow<Throwable> = _errorFlow.asSharedFlow()
-
-        fun signInWithGoogleIdToken(googleSignIn: GoogleSignIn) {
-            viewModelScope.launch {
+        fun signInWithGoogleIdToken(googleSignIn: GoogleSignIn) =
+            intent {
                 googleSignIn.requestSignInWithIdToken()
                     .onSuccess { idToken: String ->
                         requestSignInToServerWithIdToken(idToken)
                     }
                     .onFailure { throwable ->
-                        _signInState.update { SignInState.Failure }
-                        _errorFlow.emit(throwable)
+                        postSideEffect(
+                            OnboardingSideEffect.ShowError(
+                                throwable.message ?: "알수 없는 문제가 생겼어요",
+                            ),
+                        )
                     }
             }
-        }
 
-        private suspend fun requestSignInToServerWithIdToken(idToken: String) {
-            userRepository.signIn(idToken)
-                .onSuccess { isAlreadyExist ->
-                    if (isAlreadyExist) {
-                        _signInState.update { SignInState.SuccessfulSignedInUser }
-                        return@onSuccess
+        private fun requestSignInToServerWithIdToken(idToken: String) =
+            intent {
+                userRepository.signIn(idToken)
+                    .onSuccess { isAlreadyExist ->
+                        when (isAlreadyExist) {
+                            true -> postSideEffect(OnboardingSideEffect.Navigation.Home)
+                            false -> postSideEffect(OnboardingSideEffect.Navigation.SignIn)
+                        }
                     }
-                    _signInState.update { SignInState.SuccessfulSignedInGuest }
-                }
-                .onFailure { throwable ->
-                    _signInState.update { SignInState.Failure }
-                    _errorFlow.emit(throwable)
-                }
-        }
+                    .onFailure { throwable ->
+                        postSideEffect(
+                            OnboardingSideEffect.ShowError(
+                                throwable.message ?: "알수 없는 문제가 생겼어요",
+                            ),
+                        )
+                    }
+            }
     }

--- a/onboarding-presentation/src/main/java/com/teamhy2/onboarding/OnboardingViewModel.kt
+++ b/onboarding-presentation/src/main/java/com/teamhy2/onboarding/OnboardingViewModel.kt
@@ -26,9 +26,7 @@ class OnboardingViewModel
                     }
                     .onFailure { throwable ->
                         postSideEffect(
-                            OnboardingSideEffect.ShowError(
-                                throwable.message ?: "알수 없는 문제가 생겼어요",
-                            ),
+                            OnboardingSideEffect.ShowError(throwable.message),
                         )
                     }
             }
@@ -44,9 +42,7 @@ class OnboardingViewModel
                     }
                     .onFailure { throwable ->
                         postSideEffect(
-                            OnboardingSideEffect.ShowError(
-                                throwable.message ?: "알수 없는 문제가 생겼어요",
-                            ),
+                            OnboardingSideEffect.ShowError(throwable.message),
                         )
                     }
             }


### PR DESCRIPTION
resolved #179 

## AS-IS
- 기존 온보딩화면은 Orbit을 이용한 MVI 패턴이 적용되어 있지 않았습니다.

## TO-BE
- Orbit을 적용하여 MVI 패턴을 적용하였습니다.
- state가 이번 화면에는 필요 없어보여 전부 제거하였습니다.
- errorFlow 또한 제거하여 sideEffect에 포함시켰습니다.

## KEY-POINT
로그인, 가입, 에러 상황 모두 체크하였는데 혹시 몰라 한 번더 체크 부탁드립니다
* 코파일럿 리뷰가 생겼네요? 한 번 눌러보겠습니다

## SCREENSHOT (Optional)
