### PR TITLE
[Refactor] 설정 화면을 MVI 리펙토링 

### DIFF
--- a/main-presentation/src/main/java/com/teamhy2/feature/main/HY2NavHost.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/HY2NavHost.kt
@@ -13,7 +13,6 @@ import com.teamhy2.feature.main.webviews.inquiry.navigation.navigateToInquiry
 import com.teamhy2.feature.setting.presentation.navigation.settingScreen
 import com.teamhy2.onboarding.navigation.Onboarding
 import com.teamhy2.onboarding.navigation.onboardingScreen
-import com.teamhy2.onboarding.navigation.popUpToOnboarding
 import com.teamhy2.onboarding.navigation.popUpToSignUp
 import com.teamhy2.onboarding.navigation.signUpScreen
 import com.teamhy2.ranking.navigation.rankingScreen
@@ -56,10 +55,9 @@ fun HY2NavHost(
 
             settingScreen(
                 noticeUrl = urls["notice"] ?: "",
-                onInquiryClick = navController::navigateToInquiry,
+                onNavigateToInquiry = navController::navigateToInquiry,
                 onLogoutOrWithdrawComplete = {
                     onLogoutOrWithdrawComplete()
-                    navController.popUpToOnboarding()
                 },
             )
 

--- a/main-presentation/src/main/java/com/teamhy2/feature/main/MainActivity.kt
+++ b/main-presentation/src/main/java/com/teamhy2/feature/main/MainActivity.kt
@@ -226,10 +226,10 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun restartMainActivity() {
+        finish()
         val intent = Intent(this, MainActivity::class.java)
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
         startActivity(intent)
-        finish()
     }
 
     companion object {

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingContract.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingContract.kt
@@ -26,7 +26,7 @@ sealed interface SettingSideEffect {
 }
 
 @Stable
-internal class OnClick {
+internal class SettingOnClick {
     var logout: () -> Unit = {}
     var withdraw: () -> Unit = {}
     var notificationSwitch: (Boolean) -> Unit = {}

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingContract.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingContract.kt
@@ -1,6 +1,7 @@
 package com.teamhy2.feature.setting.presentation
 
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import com.teamhy2.user.domain.model.UserInfo
 
 @Immutable
@@ -24,6 +25,7 @@ sealed interface SettingSideEffect {
     }
 }
 
+@Stable
 class OnClick {
     var logout: () -> Unit = {}
     var withdraw: () -> Unit = {}

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingContract.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingContract.kt
@@ -1,0 +1,34 @@
+package com.teamhy2.feature.setting.presentation
+
+import androidx.compose.runtime.Immutable
+import com.teamhy2.user.domain.model.UserInfo
+
+@Immutable
+data class SettingState(
+    val userInfo: UserInfo = UserInfo.LOADING,
+    val isLoading: Boolean = false,
+    val isNotificationSwitchChecked: Boolean = false,
+)
+
+sealed interface SettingSideEffect {
+    data class ShowError(val errorMessage: String) : SettingSideEffect
+
+    data object LogoutOrWithdrawComplete : SettingSideEffect
+
+    sealed interface Navigation : SettingSideEffect {
+        data object Inquiry : Navigation
+
+        data object ProfileModification : Navigation
+
+        data object Notice : Navigation
+    }
+}
+
+class OnClick {
+    var logout: () -> Unit = {}
+    var withdraw: () -> Unit = {}
+    var notificationSwitch: (Boolean) -> Unit = {}
+    var notice: () -> Unit = {}
+    var inquiry: () -> Unit = {}
+    var profileModify: () -> Unit = {}
+}

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingContract.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingContract.kt
@@ -26,7 +26,7 @@ sealed interface SettingSideEffect {
 }
 
 @Stable
-class OnClick {
+internal class OnClick {
     var logout: () -> Unit = {}
     var withdraw: () -> Unit = {}
     var notificationSwitch: (Boolean) -> Unit = {}

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingScreen.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.teamhy2.designsystem.common.HY2CircularLoading
 import com.teamhy2.designsystem.common.HY2Dialog
 import com.teamhy2.designsystem.ui.theme.Gray300
@@ -42,138 +41,149 @@ import com.teamhy2.designsystem.util.compositionlocal.LocalTracker
 import com.teamhy2.feature.setting.presentation.components.SettingButton
 import com.teamhy2.feature.setting.presentation.components.SettingButtonWithSwitch
 import com.teamhy2.feature.setting.presentation.components.SettingUserProfile
-import com.teamhy2.feature.setting.presentation.model.SettingUiState
 import com.teamhy2.feature.setting.presentation.navigation.navigateToProfileModification
 import com.teamhy2.hongikyeolgong2.setting.presentation.R
 import com.teamhy2.user.domain.model.UserInfo
-import kotlinx.coroutines.flow.collectLatest
+import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 
 @Composable
 fun SettingRoute(
     noticeUrl: String,
-    onInquiryClick: () -> Unit,
-    onSignOutOrWithdrawComplete: () -> Unit,
+    onNavigateToInquiry: () -> Unit,
+    onLogoutOrWithdrawComplete: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SettingViewModel = hiltViewModel(),
 ) {
-    val settingUiState by viewModel.settingUiState.collectAsStateWithLifecycle()
+    val state: SettingState by viewModel.collectAsState()
     val context = LocalContext.current
     val tracker = LocalTracker.current
 
     val localShowSnackBar = LocalShowSnackBar.current
     val localNavController = LocalNavController.current
 
-    LaunchedEffect(true) {
-        tracker.trackEvent("Setting")
-        viewModel.initSettingUiState()
-        viewModel.errorFlow.collectLatest { throwable ->
-            localShowSnackBar.showSnackBar(throwable.message)
+    viewModel.collectSideEffect {
+        when (it) {
+            is SettingSideEffect.ShowError -> {
+                localShowSnackBar.showSnackBar(it.errorMessage)
+            }
+
+            is SettingSideEffect.LogoutOrWithdrawComplete -> {
+                onLogoutOrWithdrawComplete()
+            }
+
+            SettingSideEffect.Navigation.ProfileModification -> {
+                localNavController.navigateToProfileModification()
+            }
+
+            SettingSideEffect.Navigation.Inquiry -> {
+                onNavigateToInquiry()
+            }
+
+            SettingSideEffect.Navigation.Notice -> {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(noticeUrl))
+                context.startActivity(intent)
+            }
         }
     }
 
+    LaunchedEffect(true) {
+        tracker.trackEvent("Setting")
+        viewModel.initSettingScreen()
+    }
+
     SettingScreen(
-        settingUiState = settingUiState,
-        onLogoutClick = {
-            viewModel.signOut()
-            tracker.trackEvent("LogoutButton")
-        },
-        onWithdrawClick = {
-            viewModel.withdraw()
-            tracker.trackEvent("WithdrawButton")
-        },
-        onNotificationSwitchClick = { isChecked ->
-            viewModel.updateNotificationSwitchState(isChecked)
-        },
-        onNoticeClick = {
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(noticeUrl))
-            context.startActivity(intent)
-        },
-        onInquiryClick = onInquiryClick,
-        onSignOutOrWithdrawComplete = onSignOutOrWithdrawComplete,
-        onProfileModifyClick = { localNavController.navigateToProfileModification() },
         modifier = modifier,
+        state = state,
+        onClick = {
+            logout = {
+                viewModel.logout()
+                tracker.trackEvent("LogoutButton")
+            }
+            withdraw = {
+                viewModel.withdraw()
+                tracker.trackEvent("WithdrawButton")
+            }
+            notificationSwitch = { isChecked ->
+                viewModel.toggleNotificationSwitch(isChecked)
+            }
+            notice = {
+                viewModel.onNoticeButtonClick()
+            }
+            inquiry = {
+                viewModel.onInquiryButtonClick()
+            }
+            profileModify = {
+                viewModel.onProfileModifyClick()
+            }
+        },
     )
 }
 
 @Composable
 fun SettingScreen(
-    settingUiState: SettingUiState,
-    onLogoutClick: () -> Unit,
-    onWithdrawClick: () -> Unit,
-    onNotificationSwitchClick: (Boolean) -> Unit,
-    onNoticeClick: () -> Unit,
-    onInquiryClick: () -> Unit,
-    onProfileModifyClick: () -> Unit,
-    onSignOutOrWithdrawComplete: () -> Unit,
     modifier: Modifier = Modifier,
+    state: SettingState,
+    onClick: OnClick.() -> Unit = {},
 ) {
+    val onItemClick by remember { mutableStateOf(OnClick().apply(onClick)) }
     var showSignOutDialog by remember { mutableStateOf(false) }
     var showWithdrawDialog by remember { mutableStateOf(false) }
 
-    when (settingUiState) {
-        is SettingUiState.Loading -> {
-            HY2CircularLoading()
-        }
+    if (showSignOutDialog) {
+        HY2Dialog(
+            description = stringResource(R.string.setting_logout_dialog_description),
+            leftButtonText = stringResource(R.string.setting_logout_dialog_left_button_text),
+            rightButtonText = stringResource(R.string.setting_logout_dialog_right_button_text),
+            onLeftButtonClick = {
+                showSignOutDialog = false
+                onItemClick.logout()
+            },
+            onRightButtonClick = {
+                showSignOutDialog = false
+            },
+            onDismiss = { showSignOutDialog = false },
+        )
+    }
 
-        is SettingUiState.Success -> {
-            if (showSignOutDialog) {
-                HY2Dialog(
-                    description = stringResource(R.string.setting_logout_dialog_description),
-                    leftButtonText = stringResource(R.string.setting_logout_dialog_left_button_text),
-                    rightButtonText = stringResource(R.string.setting_logout_dialog_right_button_text),
-                    onLeftButtonClick = {
-                        showSignOutDialog = false
-                        onLogoutClick()
-                    },
-                    onRightButtonClick = {
-                        showSignOutDialog = false
-                    },
-                    onDismiss = { showSignOutDialog = false },
-                )
-            }
+    if (showWithdrawDialog) {
+        HY2Dialog(
+            description = stringResource(R.string.setting_withdrawal_dialog_description),
+            leftButtonText = stringResource(R.string.setting_withdrawal_dialog_left_button_text),
+            rightButtonText = stringResource(R.string.setting_withdrawal_dialog_right_button_text),
+            onLeftButtonClick = {
+                showWithdrawDialog = false
+                onItemClick.withdraw()
+            },
+            onRightButtonClick = {
+                showWithdrawDialog = false
+            },
+            onDismiss = { showWithdrawDialog = false },
+        )
+    }
 
-            if (showWithdrawDialog) {
-                HY2Dialog(
-                    description = stringResource(R.string.setting_withdrawal_dialog_description),
-                    leftButtonText = stringResource(R.string.setting_withdrawal_dialog_left_button_text),
-                    rightButtonText = stringResource(R.string.setting_withdrawal_dialog_right_button_text),
-                    onLeftButtonClick = {
-                        showWithdrawDialog = false
-                        onWithdrawClick()
-                    },
-                    onRightButtonClick = {
-                        showWithdrawDialog = false
-                    },
-                    onDismiss = { showWithdrawDialog = false },
-                )
-            }
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        SettingBody(
+            userInfo = state.userInfo,
+            isNotificationSwitchChecked = state.isNotificationSwitchChecked,
+            onNotificationSwitchClick = onItemClick.notificationSwitch,
+            onNoticeClick = onItemClick.notice,
+            onInquiryClick = onItemClick.inquiry,
+            onProfileClick = onItemClick.profileModify,
+        )
 
-            Column(
-                modifier = modifier.fillMaxSize(),
-            ) {
-                SettingBody(
-                    userInfo = settingUiState.userInfo,
-                    isNotificationSwitchChecked = settingUiState.isNotificationSwitchChecked,
-                    onNotificationSwitchClick = onNotificationSwitchClick,
-                    onNoticeClick = onNoticeClick,
-                    onInquiryClick = onInquiryClick,
-                    onProfileClick = onProfileModifyClick,
-                )
+        Spacer(modifier = Modifier.weight(1f))
 
-                Spacer(modifier = Modifier.weight(1f))
+        SettingBottom(
+            showLogoutDialog = { showSignOutDialog = true },
+            showWithdrawDialog = { showWithdrawDialog = true },
+        )
+    }
 
-                SettingBottom(
-                    showLogoutDialog = { showSignOutDialog = true },
-                    showWithdrawDialog = { showWithdrawDialog = true },
-                )
-            }
-        }
-
-        is SettingUiState.Expired -> {
-            onSignOutOrWithdrawComplete()
-        }
-
-        is SettingUiState.Error -> Unit
+    if (state.isLoading) {
+        HY2CircularLoading()
     }
 }
 
@@ -294,7 +304,7 @@ private fun SettingScreenPreview() {
 
     val state by remember {
         mutableStateOf(
-            SettingUiState.Success(
+            SettingState(
                 isNotificationSwitchChecked = true,
                 userInfo = sampleUserInfo,
             ),
@@ -303,14 +313,8 @@ private fun SettingScreenPreview() {
 
     HY2Theme {
         SettingScreen(
-            settingUiState = state,
-            onLogoutClick = {},
-            onWithdrawClick = {},
-            onNotificationSwitchClick = {},
-            onNoticeClick = {},
-            onInquiryClick = {},
-            onSignOutOrWithdrawComplete = {},
-            onProfileModifyClick = {},
+            state = state,
+            onClick = {},
             modifier = Modifier,
         )
     }

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingScreen.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingScreen.kt
@@ -95,7 +95,7 @@ fun SettingRoute(
     SettingScreen(
         modifier = modifier,
         state = state,
-        onClick = {
+        settingOnClick = {
             logout = {
                 viewModel.logout()
                 tracker.trackEvent("LogoutButton")
@@ -121,12 +121,12 @@ fun SettingRoute(
 }
 
 @Composable
-fun SettingScreen(
+internal fun SettingScreen(
     modifier: Modifier = Modifier,
     state: SettingState,
-    onClick: OnClick.() -> Unit = {},
+    settingOnClick: SettingOnClick.() -> Unit = {},
 ) {
-    val onItemClick = remember(onClick) { OnClick().apply(onClick) }
+    val onItemClick = remember(settingOnClick) { SettingOnClick().apply(settingOnClick) }
     var showSignOutDialog by remember { mutableStateOf(false) }
     var showWithdrawDialog by remember { mutableStateOf(false) }
 
@@ -314,7 +314,7 @@ private fun SettingScreenPreview() {
     HY2Theme {
         SettingScreen(
             state = state,
-            onClick = {},
+            settingOnClick = {},
             modifier = Modifier,
         )
     }

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingScreen.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingScreen.kt
@@ -126,7 +126,7 @@ fun SettingScreen(
     state: SettingState,
     onClick: OnClick.() -> Unit = {},
 ) {
-    val onItemClick by remember { mutableStateOf(OnClick().apply(onClick)) }
+    val onItemClick = remember(onClick) { OnClick().apply(onClick) }
     var showSignOutDialog by remember { mutableStateOf(false) }
     var showWithdrawDialog by remember { mutableStateOf(false) }
 

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingViewModel.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/SettingViewModel.kt
@@ -1,20 +1,13 @@
 package com.teamhy2.feature.setting.presentation
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.teamhy2.feature.setting.domain.repository.SettingsRepository
-import com.teamhy2.feature.setting.presentation.model.SettingUiState
 import com.teamhy2.user.domain.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.Container
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.viewmodel.container
 import javax.inject.Inject
 
 @HiltViewModel
@@ -23,69 +16,92 @@ class SettingViewModel
     constructor(
         private val settingsRepository: SettingsRepository,
         private val userRepository: UserRepository,
-    ) : ViewModel() {
-        private val _settingUiState = MutableStateFlow<SettingUiState>(SettingUiState.Loading)
-        val settingUiState: StateFlow<SettingUiState> = _settingUiState.asStateFlow()
+    ) : ViewModel(), ContainerHost<SettingState, SettingSideEffect> {
+        override val container: Container<SettingState, SettingSideEffect> =
+            container(SettingState())
 
-        private val _errorFlow = MutableSharedFlow<Throwable>()
-        val errorFlow: SharedFlow<Throwable> = _errorFlow.asSharedFlow()
-
-        fun initSettingUiState() {
-            viewModelScope.launch {
-                val userInfoResult = userRepository.getUserInfo()
-                settingsRepository.notificationSwitchState.collectLatest { isNotificationSwitchChecked ->
-                    userInfoResult
-                        .onSuccess { userInfo ->
-                            _settingUiState.update {
-                                SettingUiState.Success(
-                                    isNotificationSwitchChecked = isNotificationSwitchChecked,
-                                    userInfo = userInfo,
-                                )
-                            }
-                        }
-                        .onFailure { throwable ->
-                            _errorFlow.emit(throwable)
-                        }
+        fun initSettingScreen() =
+            intent {
+                reduce {
+                    SettingState(
+                        isLoading = true,
+                    )
                 }
-            }
-        }
 
-        fun signOut() {
-            viewModelScope.launch {
+                userRepository.getUserInfo()
+                    .onSuccess { userInfo ->
+                        // Notification 구독
+                        settingsRepository.notificationSwitchState
+                            .collectLatest { isNotificationSwitchChecked ->
+                                reduce {
+                                    state.copy(
+                                        isLoading = false,
+                                        userInfo = userInfo,
+                                        isNotificationSwitchChecked = isNotificationSwitchChecked,
+                                    )
+                                }
+                            }
+                    }
+                    .onFailure { throwable ->
+                        reduce {
+                            state.copy(
+                                isLoading = false,
+                            )
+                        }
+
+                        postSideEffect(
+                            SettingSideEffect.ShowError(
+                                throwable.message ?: "알 수 없는 문제가 생겼어요",
+                            ),
+                        )
+                    }
+            }
+
+        fun logout() =
+            intent {
                 userRepository.signOut()
                     .onSuccess {
-                        _settingUiState.update { SettingUiState.Expired }
+                        postSideEffect(SettingSideEffect.LogoutOrWithdrawComplete)
                     }
                     .onFailure { throwable ->
-                        _errorFlow.emit(throwable)
+                        postSideEffect(
+                            SettingSideEffect.ShowError(
+                                throwable.message ?: "알수 없는 문제가 생겼어요",
+                            ),
+                        )
                     }
             }
-        }
 
-        fun withdraw() {
-            viewModelScope.launch {
+        fun withdraw() =
+            intent {
                 userRepository.withdraw()
                     .onSuccess {
-                        _settingUiState.update { SettingUiState.Expired }
+                        postSideEffect(SettingSideEffect.LogoutOrWithdrawComplete)
                     }
                     .onFailure { throwable ->
-                        _errorFlow.emit(throwable)
-                    }
-            }
-        }
-
-        fun updateNotificationSwitchState(isChecked: Boolean) {
-            viewModelScope.launch {
-                settingsRepository.saveNotificationSwitchState(isChecked)
-                _settingUiState.update { currentState ->
-                    if (currentState is SettingUiState.Success) {
-                        currentState.copy(
-                            isNotificationSwitchChecked = isChecked,
+                        SettingSideEffect.ShowError(
+                            throwable.message ?: "알수 없는 문제가 생겼어요",
                         )
-                    } else {
-                        currentState
                     }
-                }
             }
-        }
+
+        fun toggleNotificationSwitch(isChecked: Boolean) =
+            intent {
+                settingsRepository.saveNotificationSwitchState(isChecked)
+            }
+
+        fun onInquiryButtonClick() =
+            intent {
+                postSideEffect(SettingSideEffect.Navigation.Inquiry)
+            }
+
+        fun onNoticeButtonClick() =
+            intent {
+                postSideEffect(SettingSideEffect.Navigation.Notice)
+            }
+
+        fun onProfileModifyClick() =
+            intent {
+                postSideEffect(SettingSideEffect.Navigation.ProfileModification)
+            }
     }

--- a/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/navigation/SettingNavigation.kt
+++ b/setting-presentation/src/main/java/com/teamhy2/feature/setting/presentation/navigation/SettingNavigation.kt
@@ -19,14 +19,14 @@ fun NavController.navigateToProfileModification() {
 
 fun NavGraphBuilder.settingScreen(
     noticeUrl: String,
-    onInquiryClick: () -> Unit,
+    onNavigateToInquiry: () -> Unit,
     onLogoutOrWithdrawComplete: () -> Unit,
 ) {
     composable(route = ROUTE) {
         SettingRoute(
             noticeUrl = noticeUrl,
-            onInquiryClick = onInquiryClick,
-            onSignOutOrWithdrawComplete = onLogoutOrWithdrawComplete,
+            onNavigateToInquiry = onNavigateToInquiry,
+            onLogoutOrWithdrawComplete = onLogoutOrWithdrawComplete,
         )
     }
     composable(route = Setting.PROFILE_MODIFICATION_ROUTE) {


### PR DESCRIPTION
resolved #184 

AS-IS
- 기존 온보딩화면은 Orbit을 이용한 MVI 패턴이 적용되어 있지 않았습니다.

TO-BE
- Orbit을 적용하여 MVI 패턴을 적용하였습니다.
- 클릭 람다들을 묶어서 관리하는 onClick을 추가하였습니다.

## KEY-POINT
on~~Click으로 입력을 호이스팅 시키다보면 Screen의 파라미터가 비대해지는 경우가 있습니다. 이를 해결하기 위해 Contract에 OnClick을 정의하여 스크린에서는  `onClick` 하나의 파라미터로 행동등을 받아오는 방식으로 리펙토링을 하였습니다. (회사에서 쓰는 방법인데 좋은 방법인거 같아서 차용하였습니다.)

```kotlin
class OnClick {
    var logout: () -> Unit = {}
    var withdraw: () -> Unit = {}
    var notificationSwitch: (Boolean) -> Unit = {}
    var notice: () -> Unit = {}
    var inquiry: () -> Unit = {}
    var profileModify: () -> Unit = {}
}

Screen(
    onClick: OnClick.() -> Unit = {},
) {
    val onItemClick by remember { mutableStateOf(OnClick().apply(onClick)) }
```

## TO-REVIEWER
mvi를 준수하려다보니 onInquiryButtonClick 같은 그저 Effect를 쏘기위한 viewModel 함수들이 늘어나게 되는데 이건 어쩔 수 없는 보일러플레이트겠죠?

모든 이동과 로직을 테스트 해보았는데 가능하시다면 더블 체크 부탁드립니다! 궁금한점은 언제든 연락주세요!

## SCREENSHOT (Optional)
