### PR TITLE
[Refactor] Ranking에서 Orbit을 제거하고 MVI로 리팩터링 합니다.

### DIFF
--- a/ranking-domain/src/main/java/com/teamhy2/ranking/WeekNumberCalculator.kt
+++ b/ranking-domain/src/main/java/com/teamhy2/ranking/WeekNumberCalculator.kt
@@ -3,7 +3,14 @@ package com.teamhy2.ranking
 import java.time.LocalDate
 import java.time.temporal.WeekFields
 
-object WeekNumberCalculator {
+class WeekNumberCalculator(now: LocalDate) {
+    var currentWeekNumber: Int = calculateWeekNumber(now)
+        private set
+    val latestWeekNumber: Int = currentWeekNumber
+
+    val isSameCurrentWeekAndLatestWeek: Boolean
+        get() = currentWeekNumber == latestWeekNumber
+
     /**
      * 주어진 날짜에 대해 weekNumber를 계산한다.
      *
@@ -15,29 +22,35 @@ object WeekNumberCalculator {
      * 반환 형식: year * 100 + weekIndex
      * 예) 2025년 9번째 주 → 202509
      */
-    fun calculateWeekNumber(date: LocalDate): Int {
+    private fun calculateWeekNumber(date: LocalDate): Int {
         val weekFields: WeekFields = WeekFields.ISO
         val weekOfYear: Int = date.get(weekFields.weekOfWeekBasedYear())
         val year: Int = date.get(weekFields.weekBasedYear())
         return year * 100 + weekOfYear
     }
 
-    fun shiftWeekNumber(
-        weekNumber: Int,
-        offset: Int,
-    ): Int {
+    fun shiftWeekNumber(offset: Int) {
         val weekFields: WeekFields = WeekFields.ISO
-        val year: Int = weekNumber / 100
-        val weekOfYear: Int = weekNumber % 100
+        val year: Int = currentWeekNumber / 100
+        val weekOfYear: Int = currentWeekNumber % 100
 
         val firstWeekMondayOfYear: LocalDate =
             LocalDate.of(year, 1, 1)
                 .with(weekFields.dayOfWeek(), 1L)
 
-        val currentWeekMonday: LocalDate = firstWeekMondayOfYear.plusWeeks((weekOfYear - 1).toLong())
+        val currentWeekMonday: LocalDate =
+            firstWeekMondayOfYear.plusWeeks((weekOfYear - 1).toLong())
 
         val newWeekMonday: LocalDate = currentWeekMonday.plusWeeks(offset.toLong())
 
-        return calculateWeekNumber(newWeekMonday)
+        currentWeekNumber = calculateWeekNumber(newWeekMonday)
+    }
+
+    fun moveToPreviousWeek() {
+        shiftWeekNumber(-1)
+    }
+
+    fun moveToNextWeek() {
+        shiftWeekNumber(1)
     }
 }

--- a/ranking-domain/src/main/java/com/teamhy2/ranking/WeekNumberCalculator.kt
+++ b/ranking-domain/src/main/java/com/teamhy2/ranking/WeekNumberCalculator.kt
@@ -3,12 +3,15 @@ package com.teamhy2.ranking
 import java.time.LocalDate
 import java.time.temporal.WeekFields
 
-class WeekNumberCalculator(now: LocalDate) {
+class WeekNumberCalculator(now: LocalDate = LocalDate.now()) {
     var currentWeekNumber: Int = calculateWeekNumber(now)
         private set
     val latestWeekNumber: Int = currentWeekNumber
 
-    val isSameCurrentWeekAndLatestWeek: Boolean
+    val isMinimumWeekNumber: Boolean
+        get() = currentWeekNumber == MINIMUM_WEEK_NUMBER
+
+    val isMaximumWeekNumber: Boolean
         get() = currentWeekNumber == latestWeekNumber
 
     /**
@@ -52,5 +55,9 @@ class WeekNumberCalculator(now: LocalDate) {
 
     fun moveToNextWeek() {
         shiftWeekNumber(1)
+    }
+
+    companion object {
+        private const val MINIMUM_WEEK_NUMBER = 202401
     }
 }

--- a/ranking-domain/src/test/kotlin/com/teamhy2/ranking/WeekNumberCalculatorTest.kt
+++ b/ranking-domain/src/test/kotlin/com/teamhy2/ranking/WeekNumberCalculatorTest.kt
@@ -5,56 +5,88 @@ import io.kotest.matchers.shouldBe
 import java.time.LocalDate
 
 class WeekNumberCalculatorTest : BehaviorSpec({
-    Given("날짜(LocalDate)가 주어지면 weekNumber를 계산할 수 있다") {
-        When("날짜가 2025년 1월 6일(월요일)인 경우") {
-            val date: LocalDate = LocalDate.of(2025, 1, 6)
-            val weekNumber: Int = WeekNumberCalculator.calculateWeekNumber(date)
+    Given("날짜가 2025년 1월 6일(월요일)인 경우") {
+        val date: LocalDate = LocalDate.of(2025, 1, 6)
+
+        When("현재 주 번호를 계산하면") {
+            val weekNumberCalculator = WeekNumberCalculator(date)
+            val actualWeekNumber: Int = weekNumberCalculator.currentWeekNumber
 
             Then("주 번호는 202502가 되어야 한다") {
-                weekNumber shouldBe 202502
-            }
-        }
-
-        When("날짜가 2025년 12월 31일(수요일)인 경우") {
-            val date: LocalDate = LocalDate.of(2025, 12, 31)
-            val weekNumber: Int = WeekNumberCalculator.calculateWeekNumber(date)
-
-            Then("주 번호는 202601이 되어야 한다") {
-                weekNumber shouldBe 202601
+                actualWeekNumber shouldBe 202502
             }
         }
     }
 
-    Given("현재 weekNumber를 기반으로 다음주 or 저번주 weekNumber를 계산할 수 있다") {
-        When("202502에서 +1 주 이동하면") {
-            val shiftedWeek: Int = WeekNumberCalculator.shiftWeekNumber(202502, 1)
+    Given("날짜가 2025년 12월 31일(수요일)인 경우") {
+        val date: LocalDate = LocalDate.of(2025, 12, 31)
 
-            Then("202503이 되어야 한다") {
-                shiftedWeek shouldBe 202503
+        When("현재 주 번호를 계산하면") {
+            val weekNumberCalculator = WeekNumberCalculator(date)
+            val actualWeekNumber: Int = weekNumberCalculator.currentWeekNumber
+
+            Then("주 번호는 202601이 되어야 한다") {
+                actualWeekNumber shouldBe 202601
+            }
+        }
+    }
+
+    Given("날짜가 2025년 1월 6일로 주 번호가 202502이고") {
+        val date: LocalDate = LocalDate.of(2025, 1, 6)
+
+        When("다음 주로 이동하면") {
+            val weekNumberCalculator = WeekNumberCalculator(date)
+            val initWeekNumber = weekNumberCalculator.currentWeekNumber
+            weekNumberCalculator.moveToNextWeek()
+            val actualCurrentWeekNumber = weekNumberCalculator.currentWeekNumber
+
+            Then("현재 주 번호는 202503이다") {
+                initWeekNumber shouldBe 202502
+                actualCurrentWeekNumber shouldBe 202503
             }
         }
 
-        When("202502에서 -1 주 이동하면") {
-            val shiftedWeek: Int = WeekNumberCalculator.shiftWeekNumber(202502, -1)
+        When("이전 주로 이동하면") {
+            val weekNumberCalculator = WeekNumberCalculator(date)
+            val initWeekNumber = weekNumberCalculator.currentWeekNumber
+            weekNumberCalculator.moveToPreviousWeek()
+            val actualCurrentWeekNumber = weekNumberCalculator.currentWeekNumber
 
-            Then("202501이 되어야 한다") {
-                shiftedWeek shouldBe 202501
+            Then("현재 주 번호는 202501이다") {
+                initWeekNumber shouldBe 202502
+                actualCurrentWeekNumber shouldBe 202501
             }
         }
+    }
 
-        When("202501에서 -1 주 이동하면") {
-            val shiftedWeek: Int = WeekNumberCalculator.shiftWeekNumber(202501, -1)
+    Given("날짜가 2025년 1월 1일로 주 번호가 202501이고") {
+        val date: LocalDate = LocalDate.of(2025, 1, 1)
 
-            Then("2024년의 마지막 주, 즉 202452가 되어야 한다") {
-                shiftedWeek shouldBe 202452
+        When("이전 주로 이동하면") {
+            val weekNumberCalculator = WeekNumberCalculator(date)
+            val initWeekNumber = weekNumberCalculator.currentWeekNumber
+            weekNumberCalculator.moveToPreviousWeek()
+            val actualCurrentWeekNumber = weekNumberCalculator.currentWeekNumber
+
+            Then("현재 주 번호는 202452이다.") {
+                initWeekNumber shouldBe 202501
+                actualCurrentWeekNumber shouldBe 202452
             }
         }
+    }
 
-        When("202452에서 +1 주 이동하면") {
-            val shiftedWeek: Int = WeekNumberCalculator.shiftWeekNumber(202452, 1)
+    Given("날짜가 2024년 12월 29일(일)로 주 번호가 202452이고") {
+        val date: LocalDate = LocalDate.of(2024, 12, 29)
 
-            Then("2025년의 첫 주, 즉 202501이 되어야 한다") {
-                shiftedWeek shouldBe 202501
+        When("다음 주로 이동하면") {
+            val weekNumberCalculator = WeekNumberCalculator(date)
+            val initWeekNumber = weekNumberCalculator.currentWeekNumber
+            weekNumberCalculator.moveToNextWeek()
+            val actualCurrentWeekNumber = weekNumberCalculator.currentWeekNumber
+
+            Then("현재 주 번호는 202501이다.") {
+                initWeekNumber shouldBe 202452
+                actualCurrentWeekNumber shouldBe 202501
             }
         }
     }

--- a/ranking-domain/src/test/kotlin/com/teamhy2/ranking/WeekNumberCalculatorTest.kt
+++ b/ranking-domain/src/test/kotlin/com/teamhy2/ranking/WeekNumberCalculatorTest.kt
@@ -90,4 +90,57 @@ class WeekNumberCalculatorTest : BehaviorSpec({
             }
         }
     }
+
+    Given("날짜가 2024년 1월 1일로 주 번호가 202401이고") {
+        val date: LocalDate = LocalDate.of(2024, 1, 1)
+        val weekNumberCalculator = WeekNumberCalculator(date)
+
+        When("현재 최소 주 번호인지 확인하면") {
+            val actual = weekNumberCalculator.isMinimumWeekNumber
+
+            Then("true이다") {
+                actual shouldBe true
+            }
+        }
+    }
+
+    Given("날짜가 2024년 1월 8일로 주 번호가 202402이고") {
+        val date: LocalDate = LocalDate.of(2024, 1, 8)
+        val weekNumberCalculator = WeekNumberCalculator(date)
+
+        When("현재 최소 주 번호인지 확인하면") {
+            val actual = weekNumberCalculator.isMinimumWeekNumber
+
+            Then("false이다") {
+                actual shouldBe false
+            }
+        }
+    }
+
+    Given("현재 날짜가 주어지고") {
+        val date: LocalDate = LocalDate.now()
+        val weekNumberCalculator = WeekNumberCalculator(date)
+
+        When("현재 주 번호가 최대 주 번호인지 확인하면") {
+            val actual = weekNumberCalculator.isMaximumWeekNumber
+
+            Then("true이다") {
+                actual shouldBe true
+            }
+        }
+    }
+
+    Given("현재 날짜에서 이전 주로 이동하고") {
+        val date: LocalDate = LocalDate.now()
+        val weekNumberCalculator = WeekNumberCalculator(date)
+        weekNumberCalculator.moveToPreviousWeek()
+
+        When("현재 주 번호가 최대 주 번호인지 확인하면") {
+            val actual = weekNumberCalculator.isMaximumWeekNumber
+
+            Then("true이다") {
+                actual shouldBe false
+            }
+        }
+    }
 })

--- a/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingContract.kt
+++ b/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingContract.kt
@@ -1,5 +1,8 @@
 package com.teamhy2.ranking
 
+import com.teamhy2.designsystem.util.mvi.SideEffect
+import com.teamhy2.designsystem.util.mvi.UiIntent
+import com.teamhy2.designsystem.util.mvi.UiState
 import com.teamhy2.ranking.model.DepartmentRanking
 
 data class RankingState(
@@ -7,8 +10,16 @@ data class RankingState(
     val currentWeek: String = "",
     val departmentRankings: List<DepartmentRanking> = emptyList(),
     val isNextWeekEnabled: Boolean = false,
-)
+) : UiState
 
-sealed interface RankingSideEffect {
+sealed interface RankingIntent : UiIntent {
+    data object EnterRankingScreen : RankingIntent
+
+    data object MoveToNextMonth : RankingIntent
+
+    data object MoveToPreviousMonth : RankingIntent
+}
+
+sealed interface RankingSideEffect : SideEffect {
     data class ShowError(val throwable: Throwable) : RankingSideEffect
 }

--- a/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingContract.kt
+++ b/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingContract.kt
@@ -4,13 +4,18 @@ import com.teamhy2.designsystem.util.mvi.SideEffect
 import com.teamhy2.designsystem.util.mvi.UiIntent
 import com.teamhy2.designsystem.util.mvi.UiState
 import com.teamhy2.ranking.model.DepartmentRanking
+import kotlinx.collections.immutable.ImmutableList
 
-data class RankingState(
-    val isLoading: Boolean = false,
-    val currentWeek: String = "",
-    val departmentRankings: List<DepartmentRanking> = emptyList(),
-    val isNextWeekEnabled: Boolean = false,
-) : UiState
+sealed interface RankingUiState : UiState {
+    data object Loading : RankingUiState
+
+    data class Loaded(
+        val currentWeek: String,
+        val departmentRankings: ImmutableList<DepartmentRanking>,
+        val canMoveToPreviousWeek: Boolean,
+        val canMoveToNextWeek: Boolean,
+    ) : RankingUiState
+}
 
 sealed interface RankingIntent : UiIntent {
     data object EnterRankingScreen : RankingIntent

--- a/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingScreen.kt
+++ b/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.teamhy2.designsystem.common.HY2LoadingScreen
 import com.teamhy2.designsystem.ui.theme.BackgroundBlack
 import com.teamhy2.designsystem.ui.theme.Gray100
@@ -37,77 +38,89 @@ import com.teamhy2.ranking.components.RankingItem
 import com.teamhy2.ranking.model.DepartmentRanking
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
-import org.orbitmvi.orbit.compose.collectAsState
-import org.orbitmvi.orbit.compose.collectSideEffect
 
 @Composable
 fun RankingRoute(
     modifier: Modifier = Modifier,
     rankingViewModel: RankingViewModel = hiltViewModel(),
 ) {
-    val state: RankingState by rankingViewModel.collectAsState()
+    val state by rankingViewModel.uiState.collectAsStateWithLifecycle()
     val localShowSnackBar = LocalShowSnackBar.current
     val tracker = LocalTracker.current
 
-    rankingViewModel.collectSideEffect { sideEffect ->
-        when (sideEffect) {
-            is RankingSideEffect.ShowError -> {
-                localShowSnackBar.showSnackBar(sideEffect.throwable.message)
+    LaunchedEffect(Unit) {
+        tracker.trackEvent("Ranking")
+
+        rankingViewModel.sendIntent(RankingIntent.EnterRankingScreen)
+
+        rankingViewModel.sideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                is RankingSideEffect.ShowError -> {
+                    localShowSnackBar.showSnackBar(sideEffect.throwable.message)
+                }
             }
         }
     }
 
-    LaunchedEffect(true) {
-        tracker.trackEvent("Ranking")
-    }
-
-    RankingScreen(
-        isLoading = state.isLoading,
-        currentWeek = state.currentWeek,
-        departmentRankings = state.departmentRankings.toImmutableList(),
-        isNextWeekEnabled = state.isNextWeekEnabled,
-        onLastWeekClick = { rankingViewModel.getLastWeekRanking() },
-        onNextWeekClick = { rankingViewModel.getNextWeekRanking() },
-        modifier =
-            modifier
-                .background(BackgroundBlack)
-                .padding(horizontal = 24.dp)
-                .fillMaxSize(),
+    RankingContent(
+        state = state,
+        onPreviousWeekClick = { rankingViewModel.sendIntent(RankingIntent.MoveToPreviousMonth) },
+        onNextWeekClick = { rankingViewModel.sendIntent(RankingIntent.MoveToNextMonth) },
+        modifier = modifier,
     )
 }
 
 @Composable
+fun RankingContent(
+    state: RankingUiState,
+    onPreviousWeekClick: () -> Unit,
+    onNextWeekClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (state) {
+        is RankingUiState.Loading -> HY2LoadingScreen()
+        is RankingUiState.Loaded ->
+            RankingScreen(
+                state = state,
+                onPreviousWeekClick = onPreviousWeekClick,
+                onNextWeekClick = onNextWeekClick,
+                modifier =
+                    modifier
+                        .background(BackgroundBlack)
+                        .padding(horizontal = 24.dp)
+                        .fillMaxSize(),
+            )
+    }
+}
+
+@Composable
 fun RankingScreen(
-    isLoading: Boolean,
-    currentWeek: String,
-    departmentRankings: ImmutableList<DepartmentRanking>,
-    isNextWeekEnabled: Boolean,
-    onLastWeekClick: () -> Unit,
+    state: RankingUiState.Loaded,
+    onPreviousWeekClick: () -> Unit,
     onNextWeekClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier,
     ) {
-        RankingHeader(
-            currentWeek = currentWeek,
-            onLastWeekClick = onLastWeekClick,
+        WeekController(
+            currentWeek = state.currentWeek,
+            onPreviousWeekClick = onPreviousWeekClick,
             onNextWeekClick = onNextWeekClick,
-            isNextWeekEnabled = isNextWeekEnabled,
+            previousWeekEnabled = state.canMoveToPreviousWeek,
+            nextWeekEnabled = state.canMoveToNextWeek,
         )
         Spacer(modifier = Modifier.height(20.dp))
-        when (isLoading) {
-            true -> HY2LoadingScreen()
-            false -> RankingBody(departmentRankings = departmentRankings)
-        }
+        Ranking(departmentRankings = state.departmentRankings)
     }
 }
 
 @Composable
-fun RankingHeader(
+fun WeekController(
     currentWeek: String,
-    isNextWeekEnabled: Boolean,
-    onLastWeekClick: () -> Unit,
+    previousWeekEnabled: Boolean,
+    nextWeekEnabled: Boolean,
+    onPreviousWeekClick: () -> Unit,
     onNextWeekClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -120,27 +133,31 @@ fun RankingHeader(
     ) {
         Text(text = currentWeek, style = HY2Typography().title01, color = Gray100)
         Spacer(modifier = Modifier.weight(1F))
-        IconButton(onClick = onLastWeekClick) {
+        IconButton(
+            onClick = onPreviousWeekClick,
+            enabled = previousWeekEnabled,
+        ) {
             Image(
                 painter = painterResource(id = R.drawable.ic_ranking_last_week),
                 contentDescription = null,
+                colorFilter = if (previousWeekEnabled.not()) ColorFilter.tint(Gray800) else null,
             )
         }
         IconButton(
             onClick = onNextWeekClick,
-            enabled = isNextWeekEnabled,
+            enabled = nextWeekEnabled,
         ) {
             Image(
                 painter = painterResource(id = R.drawable.ic_ranking_next_week),
                 contentDescription = null,
-                colorFilter = if (isNextWeekEnabled.not()) ColorFilter.tint(Gray800) else null,
+                colorFilter = if (nextWeekEnabled.not()) ColorFilter.tint(Gray800) else null,
             )
         }
     }
 }
 
 @Composable
-fun RankingBody(
+fun Ranking(
     departmentRankings: ImmutableList<DepartmentRanking>,
     modifier: Modifier = Modifier,
 ) {
@@ -229,11 +246,19 @@ fun RankingScreenPreview() {
         ).toImmutableList()
 
     RankingScreen(
-        isLoading = false,
-        currentWeek = "9월 1주차",
-        departmentRankings = sampleDepartmentRankings,
-        onLastWeekClick = {},
+        state =
+            RankingUiState.Loaded(
+                currentWeek = "9월 1주차",
+                departmentRankings = sampleDepartmentRankings,
+                canMoveToPreviousWeek = true,
+                canMoveToNextWeek = true,
+            ),
+        onPreviousWeekClick = {},
         onNextWeekClick = {},
-        isNextWeekEnabled = true,
+        modifier =
+            Modifier
+                .background(BackgroundBlack)
+                .padding(horizontal = 24.dp)
+                .fillMaxSize(),
     )
 }

--- a/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingScreen.kt
+++ b/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingScreen.kt
@@ -71,7 +71,7 @@ fun RankingRoute(
 }
 
 @Composable
-fun RankingContent(
+private fun RankingContent(
     state: RankingUiState,
     onPreviousWeekClick: () -> Unit,
     onNextWeekClick: () -> Unit,
@@ -94,7 +94,7 @@ fun RankingContent(
 }
 
 @Composable
-fun RankingScreen(
+private fun RankingScreen(
     state: RankingUiState.Loaded,
     onPreviousWeekClick: () -> Unit,
     onNextWeekClick: () -> Unit,
@@ -116,7 +116,7 @@ fun RankingScreen(
 }
 
 @Composable
-fun WeekController(
+private fun WeekController(
     currentWeek: String,
     previousWeekEnabled: Boolean,
     nextWeekEnabled: Boolean,
@@ -157,7 +157,7 @@ fun WeekController(
 }
 
 @Composable
-fun Ranking(
+private fun Ranking(
     departmentRankings: ImmutableList<DepartmentRanking>,
     modifier: Modifier = Modifier,
 ) {
@@ -180,7 +180,7 @@ fun Ranking(
 
 @Preview(showBackground = true)
 @Composable
-fun RankingScreenPreview() {
+private fun RankingScreenPreview() {
     val sampleDepartmentRankings =
         listOf(
             DepartmentRanking(

--- a/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingViewModel.kt
+++ b/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingViewModel.kt
@@ -1,12 +1,9 @@
 package com.teamhy2.ranking
 
-import androidx.lifecycle.ViewModel
+import com.teamhy2.designsystem.util.mvi.MviViewModel
 import com.teamhy2.ranking.repository.RankingRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import org.orbitmvi.orbit.Container
-import org.orbitmvi.orbit.ContainerHost
-import org.orbitmvi.orbit.viewmodel.container
-import java.time.LocalDate
+import kotlinx.collections.immutable.toImmutableList
 import javax.inject.Inject
 
 @HiltViewModel
@@ -14,45 +11,46 @@ class RankingViewModel
     @Inject
     constructor(
         private val rankingRepository: RankingRepository,
-    ) : ViewModel(), ContainerHost<RankingState, RankingSideEffect> {
-        override val container: Container<RankingState, RankingSideEffect> = container(RankingState())
-
-        private var currentWeekNumber: Int = WeekNumberCalculator.calculateWeekNumber(LocalDate.now())
-        private val latestWeekNumber: Int = currentWeekNumber
-
-        init {
-            getDepartmentRankings(currentWeekNumber)
-        }
-
-        private fun getDepartmentRankings(weekNumber: Int) =
-            intent {
-                reduce { state.copy(isLoading = true) }
-                rankingRepository.fetchRanking(weekNumber)
-                    .onSuccess { ranking ->
-                        currentWeekNumber = weekNumber
-                        reduce {
-                            state.copy(
-                                isLoading = false,
-                                currentWeek = ranking.weekName,
-                                departmentRankings = ranking.departmentRankings,
-                                isNextWeekEnabled = currentWeekNumber < latestWeekNumber,
-                            )
-                        }
-                    }
-                    .onFailure { throwable ->
-                        reduce { state.copy(isLoading = false) }
-                        postSideEffect(RankingSideEffect.ShowError(throwable))
-                    }
+        private val weekNumberCalculator: WeekNumberCalculator,
+    ) : MviViewModel<RankingIntent, RankingUiState, RankingSideEffect>(RankingUiState.Loading) {
+        override suspend fun reduceState(
+            current: RankingUiState,
+            intent: RankingIntent,
+        ): RankingUiState {
+            return when (intent) {
+                is RankingIntent.EnterRankingScreen -> getDepartmentRankings(current)
+                is RankingIntent.MoveToPreviousMonth -> getPreviousWeekRanking(current)
+                is RankingIntent.MoveToNextMonth -> getNextWeekRanking(current)
             }
-
-        fun getLastWeekRanking() {
-            val lastWeekNumber: Int = WeekNumberCalculator.shiftWeekNumber(currentWeekNumber, -1)
-            getDepartmentRankings(lastWeekNumber)
         }
 
-        fun getNextWeekRanking() {
-            if (currentWeekNumber >= latestWeekNumber) return
-            val nextWeekNumber = WeekNumberCalculator.shiftWeekNumber(currentWeekNumber, 1)
-            getDepartmentRankings(nextWeekNumber)
+        private suspend fun getDepartmentRankings(current: RankingUiState): RankingUiState {
+            return rankingRepository.fetchRanking(weekNumberCalculator.currentWeekNumber)
+                .fold(
+                    onSuccess = { ranking ->
+                        RankingUiState.Loaded(
+                            currentWeek = ranking.weekName,
+                            departmentRankings = ranking.departmentRankings.toImmutableList(),
+                            canMoveToPreviousWeek = weekNumberCalculator.isMinimumWeekNumber.not(),
+                            canMoveToNextWeek = weekNumberCalculator.isMaximumWeekNumber.not(),
+                        )
+                    },
+                    onFailure = { throwable ->
+                        postSideEffect(RankingSideEffect.ShowError(throwable))
+                        current
+                    },
+                )
+        }
+
+        private suspend fun getPreviousWeekRanking(current: RankingUiState): RankingUiState {
+            if (weekNumberCalculator.isMinimumWeekNumber) return current
+            weekNumberCalculator.moveToPreviousWeek()
+            return getDepartmentRankings(current)
+        }
+
+        private suspend fun getNextWeekRanking(current: RankingUiState): RankingUiState {
+            if (weekNumberCalculator.isMaximumWeekNumber) return current
+            weekNumberCalculator.moveToNextWeek()
+            return getDepartmentRankings(current)
         }
     }

--- a/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingViewModel.kt
+++ b/ranking-presentation/src/main/java/com/teamhy2/ranking/RankingViewModel.kt
@@ -15,11 +15,9 @@ class RankingViewModel
     constructor(
         private val rankingRepository: RankingRepository,
     ) : ViewModel(), ContainerHost<RankingState, RankingSideEffect> {
-        override val container: Container<RankingState, RankingSideEffect> =
-            container(RankingState())
+        override val container: Container<RankingState, RankingSideEffect> = container(RankingState())
 
-        private var currentWeekNumber: Int =
-            WeekNumberCalculator.calculateWeekNumber(LocalDate.now())
+        private var currentWeekNumber: Int = WeekNumberCalculator.calculateWeekNumber(LocalDate.now())
         private val latestWeekNumber: Int = currentWeekNumber
 
         init {

--- a/ranking-presentation/src/main/java/com/teamhy2/ranking/di/WeekNumberCalculatorModule.kt
+++ b/ranking-presentation/src/main/java/com/teamhy2/ranking/di/WeekNumberCalculatorModule.kt
@@ -1,0 +1,16 @@
+package com.teamhy2.ranking.di
+
+import com.teamhy2.ranking.WeekNumberCalculator
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object WeekNumberCalculatorModule {
+    @Provides
+    fun provideWeekNumberCalculator(): WeekNumberCalculator {
+        return WeekNumberCalculator()
+    }
+}

--- a/ranking-presentation/src/test/kotlin/com/teamhy2/ranking/MockRanking.kt
+++ b/ranking-presentation/src/test/kotlin/com/teamhy2/ranking/MockRanking.kt
@@ -1,0 +1,67 @@
+package com.teamhy2.ranking
+
+import com.teamhy2.ranking.model.DepartmentRanking
+
+val mockDepartmentRankings =
+    listOf(
+        DepartmentRanking(
+            department = "국어국문학과",
+            studyDurationOfWeek = 200,
+            currentRank = 1,
+            rankChange = 1,
+        ),
+        DepartmentRanking(
+            department = "디자인학부",
+            studyDurationOfWeek = 170,
+            currentRank = 2,
+            rankChange = 1,
+        ),
+        DepartmentRanking(
+            department = "경영학부",
+            studyDurationOfWeek = 120,
+            currentRank = 3,
+            rankChange = -1,
+        ),
+        DepartmentRanking(
+            department = "건축학부",
+            studyDurationOfWeek = 80,
+            currentRank = 4,
+            rankChange = 1,
+        ),
+        DepartmentRanking(
+            department = "불어불문학과",
+            studyDurationOfWeek = 78,
+            currentRank = 5,
+            rankChange = -4,
+        ),
+        DepartmentRanking(
+            department = "사회교육과",
+            studyDurationOfWeek = 60,
+            currentRank = 6,
+            rankChange = 0,
+        ),
+        DepartmentRanking(
+            department = "수학교육과",
+            studyDurationOfWeek = 56,
+            currentRank = 7,
+            rankChange = 2,
+        ),
+        DepartmentRanking(
+            department = "국어교육과",
+            studyDurationOfWeek = 50,
+            currentRank = 8,
+            rankChange = 1,
+        ),
+        DepartmentRanking(
+            department = "체육교육과",
+            studyDurationOfWeek = 45,
+            currentRank = 9,
+            rankChange = -2,
+        ),
+        DepartmentRanking(
+            department = "음악교육과",
+            studyDurationOfWeek = 40,
+            currentRank = 10,
+            rankChange = 3,
+        ),
+    )

--- a/ranking-presentation/src/test/kotlin/com/teamhy2/ranking/RankingViewModelTest.kt
+++ b/ranking-presentation/src/test/kotlin/com/teamhy2/ranking/RankingViewModelTest.kt
@@ -1,0 +1,113 @@
+package com.teamhy2.ranking
+
+import app.cash.turbine.test
+import com.teamhy2.ranking.model.Ranking
+import com.teamhy2.ranking.repository.RankingRepository
+import com.teamhy2.testing.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import java.time.LocalDate
+import kotlin.test.assertEquals
+
+class RankingViewModelTest {
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
+    private lateinit var viewModel: RankingViewModel
+    private val rankingRepository: RankingRepository = mockk()
+    private lateinit var weekNumberCalculator: WeekNumberCalculator
+
+    @Test
+    fun `RankingViewModel의 초기 상태는 Loading이다`() =
+        runTest {
+            // given & when
+            weekNumberCalculator = WeekNumberCalculator(LocalDate.of(2025, 1, 1))
+            viewModel = RankingViewModel(rankingRepository, weekNumberCalculator)
+
+            // then
+            viewModel.uiState.test {
+                val actual: RankingUiState = awaitItem()
+                assertEquals(expected = RankingUiState.Loading, actual = actual)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `주 번호를 기준으로 랭킹을 가져올 수 있다`() =
+        runTest {
+            // given
+            val weekNumber = 202501
+            val weekName = "1월 1주차"
+            weekNumberCalculator = WeekNumberCalculator(LocalDate.of(2025, 1, 1))
+            coEvery { rankingRepository.fetchRanking(weekNumber) } returns
+                Result.success(Ranking(weekName, mockDepartmentRankings))
+            viewModel = RankingViewModel(rankingRepository, weekNumberCalculator)
+
+            viewModel.uiState.test {
+                val initState: RankingUiState = awaitItem()
+                assertEquals(expected = RankingUiState.Loading, actual = initState)
+
+                // when
+                viewModel.sendIntent(RankingIntent.EnterRankingScreen)
+                val actual: RankingUiState = awaitItem()
+
+                // then
+                assertEquals(
+                    expected =
+                        RankingUiState.Loaded(
+                            currentWeek = weekName,
+                            departmentRankings = mockDepartmentRankings.toImmutableList(),
+                            canMoveToPreviousWeek = weekNumberCalculator.isMinimumWeekNumber.not(),
+                            canMoveToNextWeek = weekNumberCalculator.isMaximumWeekNumber.not(),
+                        ),
+                    actual = actual,
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+            coVerify(exactly = 1) { rankingRepository.fetchRanking(weekNumber) }
+        }
+
+    @Test
+    fun `현재 주 번호가 최소 주 번호라면 이전 주로 이동하려 할 때 최근 상태를 그대로 유지한다`() =
+        runTest {
+            // given
+            weekNumberCalculator = WeekNumberCalculator(LocalDate.of(2024, 1, 1))
+            viewModel = RankingViewModel(rankingRepository, weekNumberCalculator)
+
+            viewModel.uiState.test {
+                val initState: RankingUiState = awaitItem()
+                assertEquals(expected = RankingUiState.Loading, actual = initState)
+
+                // when
+                viewModel.sendIntent(RankingIntent.MoveToPreviousMonth)
+
+                // then: 최근 상태를 그대로 유지하기 때문에 UI State는 갱신되지 않음
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `현재 주 번호가 최대 주 번호라면 다음 주로 이동하려 할 때 최근 상태를 그대로 유지한다`() =
+        runTest {
+            // given: 오늘 날짜가 2025년 1월 1일 이라고 가정
+            weekNumberCalculator = WeekNumberCalculator(LocalDate.of(2025, 1, 1))
+            viewModel = RankingViewModel(rankingRepository, weekNumberCalculator)
+
+            viewModel.uiState.test {
+                val initState: RankingUiState = awaitItem()
+                assertEquals(expected = RankingUiState.Loading, actual = initState)
+
+                // when: 오늘 날짜보다 다음 주로 넘어가려하면
+                viewModel.sendIntent(RankingIntent.MoveToNextMonth)
+
+                // then: 최대 주 번호이기 때문에 최근 상태를 그대로 유지하기 때문에 UI State는 갱신되지 않음
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+}

--- a/ranking-presentation/src/test/kotlin/com/teamhy2/ranking/RankingViewModelTest.kt
+++ b/ranking-presentation/src/test/kotlin/com/teamhy2/ranking/RankingViewModelTest.kt
@@ -11,6 +11,7 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
+import java.io.IOException
 import java.time.LocalDate
 import kotlin.test.assertEquals
 
@@ -67,6 +68,40 @@ class RankingViewModelTest {
                     actual = actual,
                 )
                 cancelAndIgnoreRemainingEvents()
+            }
+            coVerify(exactly = 1) { rankingRepository.fetchRanking(weekNumber) }
+        }
+
+    @Test
+    fun `랭킹을 가져올 수 없다면 에러 메시지 표시를 요청한다`() =
+        runTest {
+            // given: 서버 통신이 불가능한 상황에서
+            val weekNumber = 202501
+            val serverError = IOException("서버 통신 에러")
+            weekNumberCalculator = WeekNumberCalculator(LocalDate.of(2025, 1, 1))
+            coEvery { rankingRepository.fetchRanking(weekNumber) } returns
+                Result.failure(serverError)
+            viewModel = RankingViewModel(rankingRepository, weekNumberCalculator)
+
+            viewModel.uiState.test {
+                val initState: RankingUiState = awaitItem()
+                assertEquals(expected = RankingUiState.Loading, actual = initState)
+
+                // when: 랭킹을 가져오려고 시도한다면
+                viewModel.sendIntent(RankingIntent.EnterRankingScreen)
+
+                // 더이상 UiState를 방출하지 않음
+                expectNoEvents()
+            }
+
+            viewModel.sideEffect.test {
+                val actual: RankingSideEffect = awaitItem()
+
+                // then: 랭킹을 가져오지 못했다는 에러 메시지를 요청
+                assertEquals(
+                    expected = RankingSideEffect.ShowError(serverError),
+                    actual = actual,
+                )
             }
             coVerify(exactly = 1) { rankingRepository.fetchRanking(weekNumber) }
         }

--- a/ranking-presentation/src/test/kotlin/com/teamhy2/ranking/RankingViewModelTest.kt
+++ b/ranking-presentation/src/test/kotlin/com/teamhy2/ranking/RankingViewModelTest.kt
@@ -107,6 +107,87 @@ class RankingViewModelTest {
         }
 
     @Test
+    fun `현재 주에서 이전 주로 이동할 수 있다`() =
+        runTest {
+            // given: 2024년 6월 1일이 현재라 가정할때 주 번호는 202422
+            weekNumberCalculator = WeekNumberCalculator(LocalDate.of(2024, 6, 1))
+            viewModel = RankingViewModel(rankingRepository, weekNumberCalculator)
+
+            // 이전 주의 주번호는 202421
+            coEvery { rankingRepository.fetchRanking(202421) } returns
+                Result.success(Ranking("5월 4주차", mockDepartmentRankings))
+
+            viewModel.uiState.test {
+                val initState: RankingUiState = awaitItem()
+                assertEquals(expected = RankingUiState.Loading, actual = initState)
+
+                // when
+                viewModel.sendIntent(RankingIntent.MoveToPreviousMonth)
+
+                // then
+                val actual = awaitItem()
+                assertEquals(
+                    expected =
+                        RankingUiState.Loaded(
+                            currentWeek = "5월 4주차",
+                            departmentRankings = mockDepartmentRankings.toImmutableList(),
+                            canMoveToPreviousWeek = true,
+                            canMoveToNextWeek = true,
+                        ),
+                    actual = actual,
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            coVerify(exactly = 1) { rankingRepository.fetchRanking(202421) }
+        }
+
+    @Test
+    fun `현재 주에서 다음 주로 이동할 수 있다`() =
+        runTest {
+            // given: 2024년 6월 1일이 현재라 가정할때 주 번호는 202422
+            weekNumberCalculator = WeekNumberCalculator(LocalDate.of(2024, 6, 1))
+            viewModel = RankingViewModel(rankingRepository, weekNumberCalculator)
+
+            // 현재 주가 바로 Maximum 주라 다음 주로 이동이 불가능하기 때문에 테스트를 위해 이전 주로 두번 이동 필요
+            coEvery { rankingRepository.fetchRanking(202421) } returns
+                Result.success(Ranking("5월 4주차", mockDepartmentRankings))
+            coEvery { rankingRepository.fetchRanking(202420) } returns
+                Result.success(Ranking("5월 3주차", mockDepartmentRankings))
+
+            viewModel.uiState.test {
+                val initState: RankingUiState = awaitItem()
+                assertEquals(expected = RankingUiState.Loading, actual = initState)
+
+                viewModel.sendIntent(RankingIntent.MoveToPreviousMonth)
+                viewModel.sendIntent(RankingIntent.MoveToPreviousMonth)
+                awaitItem()
+                awaitItem()
+
+                // when: 다음 주로 이동하려고 시도한다면
+                viewModel.sendIntent(RankingIntent.MoveToNextMonth)
+                assertEquals(weekNumberCalculator.currentWeekNumber, 202421)
+
+                // then: 이전 주로 두번 이동하고 다음 주로 한 번 이동하기 때문에 결과적으로 5월 4주차 데이터 방출
+                val actual = awaitItem()
+                assertEquals(
+                    expected =
+                        RankingUiState.Loaded(
+                            currentWeek = "5월 4주차",
+                            departmentRankings = mockDepartmentRankings.toImmutableList(),
+                            canMoveToPreviousWeek = true,
+                            canMoveToNextWeek = true,
+                        ),
+                    actual = actual,
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            coVerify(exactly = 2) { rankingRepository.fetchRanking(202421) }
+            coVerify(exactly = 1) { rankingRepository.fetchRanking(202420) }
+        }
+
+    @Test
     fun `현재 주 번호가 최소 주 번호라면 이전 주로 이동하려 할 때 최근 상태를 그대로 유지한다`() =
         runTest {
             // given


### PR DESCRIPTION
resolved #207 

## AS-IS
- 기존 `WeekNumberCalculator`는 object로서 자기가 관리해야할 상태를 ViewModel이 가지고 있도록 하였습니다.

## TO-BE
- `WeekNumberCalculator`가 자신의 상태를 관리하게 하여 능동적으로 상태를 기반으로 알아서 작동하게 바꿔보았습니다.

## KEY-POINT
- `RankingViewModel`에 대한 단위 테스트를 진행하였습니다.
- 24년 이전부턴 랭킹 데이터가 없기 떄문에 24년 1주차 기준으로 더이상 이전 주로 이동하지 못하게 하였으며, 테스트 완료하였습니다.
- 이전 주 혹은 다음 주로 이동할 때 짧게 로딩 표시하는 로직을 제거하였습니다.
    - 서버 통신시 25ms ~ 35ms 정도 걸립니다. 
    - 오히려 짧은 시간 동안 UI State를 갱신하고 로딩뷰를 표시하는게 오버헤드로 느껴졌습니다.
    - 추후 페이징을 고려해도 좋을 것 같습니다.

## SCREENSHOT (Optional)
![Jul-20-2025 03-05-18](https://github.com/user-attachments/assets/98d9731a-2c13-46d2-a490-46d7462888ac)

