### PR TITLE
ci: Play Store 자동 배포 파이프라인 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,116 @@
+name: Release to Play Store
+
+# Release/* 브랜치 PR이 main에 "머지"될 때만 실행된다.
+# (PR을 머지 없이 닫기만 하면 아래 if의 merged == true 조건에서 걸러져 실행되지 않음)
+on:
+  pull_request:
+    branches:
+      - "main"
+    types:
+      - closed
+  workflow_dispatch: # 필요 시 수동 재실행
+
+permissions:
+  contents: write # main에 태그를 푸시하기 위해 필요
+
+jobs:
+  release:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       startsWith(github.event.pull_request.head.ref, 'Release/'))
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main # 머지가 반영된 main 최신 커밋을 기준으로 빌드/태그
+          fetch-depth: 0 # 전체 히스토리 + 태그(중복 태그 판별용)
+
+      # 빌드/업로드 같은 비가역 작업 "전에" 버전을 검증해 빠르게 실패시킨다.
+      - name: Resolve & validate version (fail fast)
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION_NAME=$(awk -F'"' '/^versionName[[:space:]]*=/{print $2; exit}' gradle/libs.versions.toml)
+          VERSION_CODE=$(awk -F'"' '/^versionCode[[:space:]]*=/{print $2; exit}' gradle/libs.versions.toml)
+          echo "Resolved versionName=$VERSION_NAME versionCode=$VERSION_CODE"
+          [ -n "$VERSION_NAME" ] || { echo "::error::versionName을 libs.versions.toml에서 찾지 못했습니다."; exit 1; }
+          [[ "$VERSION_CODE" =~ ^[0-9]+$ ]] || { echo "::error::versionCode가 정수가 아닙니다: '$VERSION_CODE'"; exit 1; }
+          if git rev-parse -q --verify "refs/tags/$VERSION_NAME" >/dev/null; then
+            echo "::error::태그 $VERSION_NAME 가 이미 존재합니다. 릴리스 전에 gradle/libs.versions.toml의 versionCode/versionName을 올리세요."
+            exit 1
+          fi
+          echo "name=$VERSION_NAME" >> "$GITHUB_OUTPUT"
+          echo "code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: gradle # ~/.gradle 캐싱은 여기서 일원화 (별도 actions/cache 미사용)
+
+      - name: Load google-services.json
+        env:
+          DATA: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: echo "$DATA" | base64 -d > app/google-services.json
+
+      - name: Create local.properties
+        env:
+          LOCAL_PROPERTIES_CONTENTS: ${{ secrets.LOCAL_PROPERTIES_CONTENTS }}
+        run: printf '%s\n' "$LOCAL_PROPERTIES_CONTENTS" > local.properties
+
+      - name: Decode release keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          echo "$KEYSTORE_BASE64" | base64 -d > "${RUNNER_TEMP}/release.jks"
+          [ -s "${RUNNER_TEMP}/release.jks" ] || { echo "::error::디코딩된 키스토어가 비어 있습니다. KEYSTORE_BASE64 시크릿을 확인하세요."; exit 1; }
+          chmod 600 "${RUNNER_TEMP}/release.jks"
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build signed release bundle (.aab)
+        env:
+          KEYSTORE_FILE: ${{ runner.temp }}/release.jks
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          # CI에서는 서명 정보를 시크릿(env)으로만 받는다. 비어 있으면 local.properties로
+          # 조용히 폴백하지 않고 즉시 실패시킨다.
+          [ -n "${KEY_ALIAS}" ] || { echo "::error::KEY_ALIAS 시크릿이 비어 있습니다."; exit 1; }
+          [ -n "${KEYSTORE_PASSWORD}" ] || { echo "::error::KEYSTORE_PASSWORD 시크릿이 비어 있습니다."; exit 1; }
+          [ -n "${KEY_PASSWORD}" ] || { echo "::error::KEY_PASSWORD 시크릿이 비어 있습니다."; exit 1; }
+          ./gradlew :app:bundleRelease
+
+      - name: Verify AAB exists
+        run: |
+          set -euo pipefail
+          AAB=app/build/outputs/bundle/release/app-release.aab
+          [ -f "$AAB" ] || { echo "::error::예상 경로에 AAB가 없습니다: $AAB"; exit 1; }
+          echo "Built $AAB"
+
+      - name: Upload AAB to Play Store (production)
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.teamhy2.hongikyeolgong2
+          releaseFiles: app/build/outputs/bundle/release/app-release.aab
+          track: production
+          status: completed # 100% 즉시 출시. 단계적 출시는 status: inProgress + userFraction 사용
+
+      - name: Create and push git tag on main
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.version.outputs.name }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG (versionCode ${{ steps.version.outputs.code }})"
+          git push origin "$TAG"
+          echo "Pushed tag $TAG"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,8 +1,35 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     id("hongikyeolgong2.android.application")
     alias(libs.plugins.google.services)
     id("com.google.firebase.crashlytics")
 }
+
+// local.properties(로컬 개발용)에서 서명 정보를 읽되, CI에서는 환경 변수가 우선한다.
+val localProperties =
+    Properties().apply {
+        val file = rootProject.file("local.properties")
+        if (file.exists()) {
+            FileInputStream(file).use { load(it) }
+        }
+    }
+
+// 우선순위: 환경 변수(CI) > local.properties(로컬). 둘 다 없으면 null.
+fun signingProperty(
+    propertyKey: String,
+    envKey: String,
+): String? =
+    (System.getenv(envKey) ?: localProperties.getProperty(propertyKey))
+        ?.trim()
+        ?.removeSurrounding("\"")
+        ?.takeIf { it.isNotBlank() }
+
+val keystorePath = signingProperty("storeFile", "KEYSTORE_FILE")
+// 키스토어 파일이 실제로 존재할 때만 release 서명을 구성한다.
+// (키스토어가 없는 일반 CI 빌드/PR 빌드는 기존처럼 서명 없이 통과)
+val hasReleaseSigning = keystorePath != null && file(keystorePath).exists()
 
 android {
     namespace = "com.teamhy2.hongikyeolgong2"
@@ -12,6 +39,17 @@ android {
         targetSdk = libs.versions.targetSdk.get().toInt()
         versionCode = libs.versions.versionCode.get().toInt()
         versionName = libs.versions.versionName.get()
+    }
+
+    signingConfigs {
+        if (hasReleaseSigning) {
+            create("release") {
+                storeFile = file(keystorePath!!)
+                storePassword = signingProperty("storePassword", "KEYSTORE_PASSWORD")
+                keyAlias = signingProperty("keyAlias", "KEY_ALIAS")
+                keyPassword = signingProperty("keyPassword", "KEY_PASSWORD")
+            }
+        }
     }
 
     buildTypes {
@@ -27,6 +65,9 @@ android {
 
         release {
             isDebuggable = false
+            if (hasReleaseSigning) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             manifestPlaceholders.putAll(
                 mapOf(
                     "appIcon" to "@mipmap/ic_app_logo",

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,159 @@
+# 릴리스 & Play Store 자동 배포 가이드
+
+## 브랜치 전략
+
+| 브랜치      | 용도                                                                                  |
+| ----------- | ------------------------------------------------------------------------------------- |
+| `develop`   | 개발 기본 브랜치. 모든 기능 작업은 여기서 분기·병합.                                   |
+| `Release/*` | 릴리스 준비 브랜치. (예: `Release/1.5.0`)                                              |
+| `main`      | 배포 브랜치. **여기에 머지되면 자동으로 Play Store에 출시**되고 태그(`X.Y.Z`)가 찍힘. |
+
+> ⚠️ 현재 원격(origin)에는 `main` 브랜치가 없습니다. 자동 배포가 동작하려면 `main` 브랜치를
+> 먼저 만들어야 합니다. (아래 "최초 1회 셋업 → 0) main 브랜치 생성" 참고)
+
+## 자동 배포 흐름
+
+```
+Release/1.5.0 ──(PR 머지)──▶ main
+                                │
+                                ▼
+          .github/workflows/release.yml 실행
+                                │
+        ┌───────────────────────┼───────────────────────┐
+        ▼                       ▼                       ▼
+  서명된 .aab 빌드      Play Store(production) 업로드   main에 1.5.0 태그 푸시
+```
+
+- 트리거: **`Release/*` 브랜치에서 `main`으로 보낸 PR이 "머지"될 때만** 실행됩니다.
+  (PR을 머지 없이 닫기만 하면 실행되지 않습니다.)
+- 빌드/업로드 같은 비가역 작업 전에 버전 검증 단계가 먼저 실행되어, 버전이 잘못됐으면 **빠르게 실패**합니다.
+- 수동 재실행이 필요하면 GitHub Actions 탭에서 `Release to Play Store` 워크플로우를 `workflow_dispatch`로 실행할 수 있습니다.
+
+---
+
+## ⚠️ 릴리스 전 필수 체크: versionCode / versionName 올리기
+
+Play Store는 **업로드할 때마다 `versionCode`가 직전보다 커야** 합니다. (같으면 업로드 거부)
+또한 현재 `1.4.0`(versionCode `10400`)은 **이미 출시되어 동일 이름의 태그가 존재**하므로,
+다음 릴리스에서는 반드시 값을 올려야 합니다.
+
+`Release/*` 브랜치에서 PR을 만들기 전에 [`gradle/libs.versions.toml`](../gradle/libs.versions.toml)을 수정하세요.
+
+```toml
+[versions]
+versionCode = "10500"   # 직전 값(10400)보다 크게
+versionName = "1.5.0"   # 태그는 1.5.0 으로 생성됨 (접두사 v 없음)
+```
+
+> 만약 값을 올리지 않으면, 워크플로우의 버전 검증 단계가 "태그가 이미 존재한다"며
+> 빌드/업로드 이전에 즉시 실패합니다. (프로덕션에 중복 업로드가 발생하지 않음)
+
+---
+
+## 최초 1회 셋업
+
+### 0) `main` 브랜치 생성 (origin에 아직 없음)
+
+현재 배포 기준이 되는 `main` 브랜치가 원격에 없습니다. 보통 가장 최근 릴리스 시점(현재 `develop` = `1.4.0`)에서 만듭니다.
+
+```bash
+git fetch origin
+git switch -c main origin/develop
+git push -u origin main
+```
+
+> 개발은 계속 `develop`에서 진행하고, 릴리스할 때만 `Release/* → main` PR을 보냅니다.
+> (GitHub 저장소의 기본 브랜치는 `develop`로 유지해도 됩니다. 원하면 `main`에 브랜치 보호 규칙을 거세요.)
+
+### GitHub Secrets 등록
+
+자동 배포가 동작하려면 아래 Secrets를 모두 등록해야 합니다.
+**저장소 → Settings → Secrets and variables → Actions → New repository secret**
+
+| Secret 이름                 | 값                                       | 상태      |
+| --------------------------- | ---------------------------------------- | --------- |
+| `GOOGLE_SERVICES_JSON`      | `app/google-services.json` 의 base64     | 이미 있음 |
+| `LOCAL_PROPERTIES_CONTENTS` | `local.properties` 내용                  | 이미 있음 |
+| `KEYSTORE_BASE64`           | 릴리스 키스토어(`.jks`)의 base64         | **추가**  |
+| `KEYSTORE_PASSWORD`         | 키스토어 비밀번호                        | **추가**  |
+| `KEY_PASSWORD`              | 키 비밀번호                              | **추가**  |
+| `KEY_ALIAS`                 | 키 별칭(alias)                           | **추가**  |
+| `PLAY_SERVICE_ACCOUNT_JSON` | Google Play 서비스 계정 JSON 키 전체 내용 | **추가**  |
+
+> 🔐 `KEYSTORE_PASSWORD`, `KEY_PASSWORD` 값은 **이 문서에 적지 마세요.** 팀에서 공유 중인
+> 키스토어 비밀번호(비밀번호 관리자/사내 보안 채널 참조)를 GitHub Secrets에만 입력합니다.
+> 비밀번호가 외부에 노출된 적이 있다면 **업로드 키 재설정/비밀번호 교체**를 권장합니다.
+
+### 1) 키스토어 관련 시크릿
+
+릴리스 서명에 쓰는 `.jks` 파일을 base64로 변환해 `KEYSTORE_BASE64`에 넣습니다. (macOS)
+
+```bash
+base64 -i /path/to/release.jks | pbcopy   # 클립보드에 복사됨 → 그대로 붙여넣기
+```
+
+> 워크플로우는 `base64 -d`로 복원하며, 줄바꿈이 포함된 base64도 정상 디코딩됩니다.
+
+키 별칭(alias)을 모르면 아래로 확인합니다.
+
+```bash
+keytool -list -v -keystore /path/to/release.jks
+# "Alias name: ..." 줄의 값이 KEY_ALIAS 입니다.
+```
+
+### 2) Google Play 서비스 계정 JSON 만들기 (아직 없음 → 1회 설정)
+
+Play Store에 API로 업로드하려면 권한이 연결된 서비스 계정 키가 필요합니다.
+
+1. **Play Console** → **설정 → API 액세스(API access)** 진입
+2. **새 서비스 계정 만들기** 안내를 따라 **Google Cloud Console**로 이동
+   - 해당 GCP 프로젝트에서 **서비스 계정 생성** (이름 예: `play-publisher`)
+   - 생성 후 **키 → 키 추가 → 새 키 만들기 → JSON** 선택 → JSON 파일 다운로드
+3. Google Cloud Console에서 **Google Play Android Developer API**가 사용 설정(Enabled)되어 있는지 확인
+4. 다시 **Play Console → API 액세스**로 돌아와 방금 만든 서비스 계정에 **권한 부여(Grant access)**
+   - 앱 권한: `com.teamhy2.hongikyeolgong2` 선택
+   - 계정 권한: **"프로덕션 트랙으로 출시"** 및 **"앱 정보 보기"** 포함
+5. 다운로드한 **JSON 파일 전체 내용**을 `PLAY_SERVICE_ACCOUNT_JSON` 시크릿에 붙여넣기
+
+> 권한 반영에는 최대 24시간이 걸릴 수 있습니다.
+
+### 3) Play App Signing / 첫 업로드 주의사항
+
+- 앱이 **Play App Signing**을 사용 중이라면 위 `.jks`는 *업로드 키*입니다. (이미 1.4.0을 올렸다면 보통 활성화되어 있음)
+- `1.4.0`이 이미 프로덕션에 출시되어 있으므로 "draft 앱" 류의 첫 업로드 제약은 발생하지 않습니다.
+- 첫 자동 배포를 안전하게 검증하고 싶다면, `.github/workflows/release.yml`의 `track: production`을
+  `track: internal`로 잠시 바꿔 내부 테스트로 한 번 돌려본 뒤 되돌리는 것을 권장합니다.
+
+---
+
+## 로컬에서 서명된 빌드를 만들고 싶다면
+
+`local.properties`에 아래 두 줄을 추가하세요. (이 파일은 git에 올라가지 않습니다.)
+
+```properties
+storeFile=/absolute/path/to/release.jks
+keyAlias=여기에_키_별칭
+# storePassword, keyPassword 는 이미 local.properties에 있음
+```
+
+그 후:
+
+```bash
+./gradlew :app:bundleRelease   # 결과: app/build/outputs/bundle/release/app-release.aab
+```
+
+> 빌드 설정은 환경 변수(`KEYSTORE_FILE`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`)를 우선 사용하고,
+> 없으면 `local.properties`를 사용합니다. 키스토어가 전혀 없으면 release는 서명 없이 빌드되어
+> 기존 CI(`android.yml`의 빌드/테스트/ktlint)는 영향받지 않습니다.
+
+---
+
+## 단계적 출시(staged rollout)로 바꾸기
+
+`release.yml`의 업로드 스텝을 아래처럼 변경하면 일부 사용자에게만 먼저 배포됩니다.
+
+```yaml
+track: production
+status: inProgress
+userFraction: 0.1 # 10%부터 시작
+```


### PR DESCRIPTION
## 개요
`Release/* → main` 머지 시 **서명된 AAB를 빌드 → Play Store(production) 업로드 → main에 버전 태그 생성**까지 자동화하는 파이프라인을 추가합니다.

## 변경 사항
- **`.github/workflows/release.yml`** (신규)
  - 트리거: `Release/*` 브랜치 PR이 `main`에 **머지될 때만** (`merged == true` + `head.ref` `Release/*`)
  - 비가역 작업(빌드/업로드) **이전에** 버전 fail-fast 검증 (versionCode 정수 확인, 동일 태그 존재 시 차단 → 중복 production 업로드 방지)
  - 키스토어 base64 디코딩 무결성 검사(`set -euo pipefail`, 빈 파일 차단, `chmod 600`)
  - `r0adkll/upload-google-play`로 production 트랙 업로드
  - 성공 시 `main`에 `X.Y.Z` 태그 푸시 (기존 태그 컨벤션과 동일, `v` 접두사 없음)
- **`app/build.gradle.kts`**
  - release `signingConfigs` 추가. 환경변수(CI) 우선 → `local.properties`(로컬) 폴백
  - 키스토어가 없으면 release를 **무서명으로 빌드** → 기존 `android.yml`(build/test/ktlint) 비파괴 (로컬 `signingReport`로 검증)
- **`docs/RELEASE.md`** (신규): 브랜치 전략, 필요한 GitHub Secrets, Google Play 서비스 계정 발급 절차, versionCode 관리 주의사항

## 병합 전/후 필요한 수동 작업 (코드로 불가)
- [ ] GitHub Secrets 등록: `KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_PASSWORD`, `KEY_ALIAS`, `PLAY_SERVICE_ACCOUNT_JSON`
- [ ] Google Play 서비스 계정 JSON 발급 + Play Console 권한 연결 (현재 미보유 → `docs/RELEASE.md` 2)번 참고)
- [ ] 다음 릴리스 시 `gradle/libs.versions.toml`의 `versionCode`/`versionName` 상향 (현재 1.4.0/10400은 이미 출시됨)

> ℹ️ `main` 브랜치는 이미 생성·푸시됨 (origin/develop 1.4.0 시점).

🤖 Generated with [Claude Code](https://claude.com/claude-code)