### PR TITLE
[Refactor] 구글 로그인 Credential Manager 베스트 프랙티스 적용

### DIFF
--- a/core/auth/src/main/java/com/teamhy2/core/auth/GoogleSignIn.kt
+++ b/core/auth/src/main/java/com/teamhy2/core/auth/GoogleSignIn.kt
@@ -1,66 +1,96 @@
 package com.teamhy2.core.auth
 
 import android.content.Context
+import android.util.Base64
 import androidx.credentials.ClearCredentialStateRequest
 import androidx.credentials.CredentialManager
+import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialRequest
 import androidx.credentials.GetCredentialResponse
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.NoCredentialException
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
 import java.security.MessageDigest
-import java.util.UUID
+import java.security.SecureRandom
 
 private typealias IdToken = String
 
 class GoogleSignIn(private val context: Context) {
     private val credentialManager = CredentialManager.create(context)
-    private val googleIdOption: GetGoogleIdOption =
-        GetGoogleIdOption.Builder()
-            .setFilterByAuthorizedAccounts(false)
-            .setServerClientId(BuildConfig.WEB_CLIENT_ID)
-            .setAutoSelectEnabled(false)
-            .setNonce(createHashedNonce())
-            .build()
-    private val credentialRequest: GetCredentialRequest =
-        GetCredentialRequest.Builder()
-            .addCredentialOption(googleIdOption)
-            .build()
 
-    private fun createHashedNonce(): String {
-        val rawNonce: String = UUID.randomUUID().toString()
-        val bytes: ByteArray = rawNonce.toByteArray()
-        val md: MessageDigest = MessageDigest.getInstance(DIGEST_ALGORITHM)
-        val digest: ByteArray = md.digest(bytes)
-        val hashedNonce: String =
-            digest.fold("") { accumulator, it ->
-                accumulator + "%02x".format(it)
-            }
-        return hashedNonce
-    }
+    suspend fun requestSignInWithIdToken(): Result<IdToken> =
+        runCatching {
+            val response = getCredentialWithFallback()
+            extractIdToken(response)
+        }
 
-    suspend fun requestSignInWithIdToken(): Result<IdToken> {
-        return runCatching {
-            val credentialResponse: GetCredentialResponse =
-                credentialManager.getCredential(
-                    request = credentialRequest,
-                    context = context,
-                )
-
-            val credential = credentialResponse.credential
-
-            val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(credential.data)
-
-            googleIdTokenCredential.idToken
+    private suspend fun getCredentialWithFallback(): GetCredentialResponse {
+        return try {
+            credentialManager.getCredential(
+                request = buildAuthorizedAccountsRequest(),
+                context = context,
+            )
+        } catch (e: NoCredentialException) {
+            credentialManager.getCredential(
+                request = buildSignInWithGoogleRequest(),
+                context = context,
+            )
         }
     }
 
-    suspend fun requestSignOut(): Result<Unit> {
-        return runCatching {
-            credentialManager.clearCredentialState(request = ClearCredentialStateRequest())
+    private fun buildAuthorizedAccountsRequest(): GetCredentialRequest {
+        val option =
+            GetGoogleIdOption.Builder()
+                .setFilterByAuthorizedAccounts(true)
+                .setAutoSelectEnabled(true)
+                .setServerClientId(BuildConfig.WEB_CLIENT_ID)
+                .setNonce(generateHashedNonce())
+                .build()
+        return GetCredentialRequest.Builder()
+            .addCredentialOption(option)
+            .build()
+    }
+
+    private fun buildSignInWithGoogleRequest(): GetCredentialRequest {
+        val option =
+            GetSignInWithGoogleOption.Builder(serverClientId = BuildConfig.WEB_CLIENT_ID)
+                .setNonce(generateHashedNonce())
+                .build()
+        return GetCredentialRequest.Builder()
+            .addCredentialOption(option)
+            .build()
+    }
+
+    private fun extractIdToken(response: GetCredentialResponse): IdToken {
+        val credential = response.credential
+        check(
+            credential is CustomCredential &&
+                credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL,
+        ) { "Unexpected credential type: ${credential::class.java.name}" }
+        return try {
+            GoogleIdTokenCredential.createFrom(credential.data).idToken
+        } catch (e: GoogleIdTokenParsingException) {
+            throw IllegalStateException("Failed to parse Google ID token", e)
         }
+    }
+
+    suspend fun requestSignOut(): Result<Unit> =
+        runCatching {
+            credentialManager.clearCredentialState(ClearCredentialStateRequest())
+        }
+
+    private fun generateHashedNonce(): String {
+        val rawBytes = ByteArray(NONCE_BYTE_LENGTH).also { SecureRandom().nextBytes(it) }
+        val rawNonce = Base64.encodeToString(rawBytes, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+        val digest = MessageDigest.getInstance(DIGEST_ALGORITHM).digest(rawNonce.toByteArray())
+        return digest.joinToString(separator = "") { "%02x".format(it) }
     }
 
     companion object {
         private const val DIGEST_ALGORITHM = "SHA-256"
+        private const val NONCE_BYTE_LENGTH = 32
     }
 }

--- a/core/auth/src/main/java/com/teamhy2/core/auth/GoogleSignIn.kt
+++ b/core/auth/src/main/java/com/teamhy2/core/auth/GoogleSignIn.kt
@@ -7,7 +7,6 @@ import androidx.credentials.CredentialManager
 import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialRequest
 import androidx.credentials.GetCredentialResponse
-import androidx.credentials.exceptions.GetCredentialException
 import androidx.credentials.exceptions.NoCredentialException
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ retrofitKotlinxSerializationJson = "1.0.0"
 kotlinxSerializationJson = "1.5.1"
 
 # Credentials
-credentials = "1.3.0-alpha01"
+credentials = "1.3.0"
 googleid = "1.1.1"
 firebaseConfigKtx = "22.0.1"
 


### PR DESCRIPTION
resolved #231

## 배경 — 어떤 문제를 발견했나

QA 도중 디버그 빌드에서 구글 로그인을 시도하면 `[16] account reauth failed` 오류로 인증이 진행되지 않는 현상을 확인했습니다. 원인 추적 과정에서 단순한 인증서 등록 문제뿐 아니라 `core/auth/GoogleSignIn.kt`의 구현 자체가 Android Credential Manager 권장 패턴에서 벗어나 있는 점이 같이 드러나서, 일괄적으로 베스트 프랙티스에 맞춰 리팩토링했습니다.

## AS-IS — 기존 구현의 문제

### 1. 잘못된 API 선택 — `GetGoogleIdOption` 단일 사용

```kotlin
private val googleIdOption: GetGoogleIdOption =
    GetGoogleIdOption.Builder()
        .setFilterByAuthorizedAccounts(false)
        .setServerClientId(BuildConfig.WEB_CLIENT_ID)
        .setAutoSelectEnabled(false)
        .setNonce(createHashedNonce())
        .build()
```

- **`GetGoogleIdOption`은 \"자동 바텀시트\" 흐름용 API**입니다. 이 앱처럼 사용자가 \"구글로 로그인\" 버튼을 명시적으로 탭하는 흐름에서는 `GetSignInWithGoogleOption`이 공식 권장 API입니다.
- `GetGoogleIdOption` + `filterByAuthorizedAccounts=false` 조합은 기기에 Google 계정이 있어도 \"이 앱에 사전 인증된 계정\"이 없거나 Play Services 상태가 어긋나면 즉시 `NoCredentialException`을 던지고 사용자는 아무 다이얼로그도 보지 못한 채 실패합니다.
- 또한 공식 가이드가 권장하는 \"`filterByAuthorizedAccounts=true` 1차 시도 → 실패 시 폴백\" 2-step 패턴이 없어서 재방문 사용자 자동 로그인 UX 이점을 못 살리고 있었습니다.

### 2. nonce 재사용 — 보안 결함

```kotlin
class GoogleSignIn(private val context: Context) {
    private val googleIdOption: GetGoogleIdOption =
        GetGoogleIdOption.Builder()
            ...
            .setNonce(createHashedNonce())  // 인스턴스 생성 시 1회만 호출
            .build()
```

- `googleIdOption`을 클래스 필드로 캐싱하기 때문에 `createHashedNonce()`도 **인스턴스당 1회만 실행**됩니다.
- 호출부는 `OnboardingScreen.kt`에서 `remember { GoogleSignIn(context) }`로 잡고 있어, 화면이 살아있는 동안 모든 로그인 시도에 **같은 nonce가 재사용**됩니다.
- nonce는 매 요청마다 새로 생성되어야 재전송 공격(replay attack)을 막을 수 있으므로 명백한 보안 결함입니다.

### 3. 응답 처리 검증 부실

```kotlin
val credential = credentialResponse.credential
val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(credential.data)
googleIdTokenCredential.idToken
```

- `credential`이 실제로 `CustomCredential`이고 type이 `TYPE_GOOGLE_ID_TOKEN_CREDENTIAL`인지 검증 없이 바로 파싱합니다.
- 공식 가이드는 type 체크 후 파싱하고, 파싱 단계의 `GoogleIdTokenParsingException`을 별도로 처리할 것을 권장합니다.

### 4. 의존성이 알파 버전

```toml
credentials = \"1.3.0-alpha01\"
```

알파 채널에는 자격증명 관련 알려진 버그가 있어 stable 채널 사용이 권장됩니다.

## TO-BE — 어떻게 개선했나

### 1. 2-step 폴백 패턴 적용

```kotlin
private suspend fun getCredentialWithFallback(): GetCredentialResponse {
    return try {
        // 1차: 사전 인증된 계정만 + 자동 선택 — 재방문 사용자 무마찰 로그인
        credentialManager.getCredential(
            request = buildAuthorizedAccountsRequest(),
            context = context,
        )
    } catch (e: NoCredentialException) {
        // 2차: 버튼 클릭 전용 공식 API — 항상 계정 선택 UI 노출, 신규 계정 추가 흐름까지 포함
        credentialManager.getCredential(
            request = buildSignInWithGoogleRequest(),
            context = context,
        )
    }
}
```

- **1차 시도**: `GetGoogleIdOption(filterByAuthorizedAccounts=true, autoSelectEnabled=true)` — 이 앱에 이전에 로그인한 적이 있는 계정이 단 하나면 다이얼로그 없이 자동 선택.
- **2차 폴백**: `NoCredentialException` 발생 시(=신규 사용자 또는 사전 인증 계정 없음) `GetSignInWithGoogleOption`으로 전환 — 버튼 클릭 UX에 맞춰 항상 계정 선택 UI를 띄우고, 기기에 Google 계정이 없으면 \"계정 추가\" 흐름까지 안내함.
- 이로써 기존 `NoCredentialException`이 사용자에게 그대로 노출되던 케이스가 자연스러운 계정 선택 UI로 대체됩니다.

### 2. nonce 매 호출 재생성

```kotlin
private fun buildAuthorizedAccountsRequest(): GetCredentialRequest {
    val option =
        GetGoogleIdOption.Builder()
            ...
            .setNonce(generateHashedNonce())  // 매 호출마다 새 nonce
            .build()
    ...
}

private fun generateHashedNonce(): String {
    val rawBytes = ByteArray(NONCE_BYTE_LENGTH).also { SecureRandom().nextBytes(it) }
    val rawNonce = Base64.encodeToString(rawBytes, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
    val digest = MessageDigest.getInstance(DIGEST_ALGORITHM).digest(rawNonce.toByteArray())
    return digest.joinToString(separator = \"\") { \"%02x\".format(it) }
}
```

- 옵션/리퀘스트 객체를 인스턴스 필드에서 함수 호출 단위로 옮겨, **`requestSignInWithIdToken()` 호출 한 번당 새 nonce 1개**가 생성되도록 변경.
- raw 엔트로피도 `UUID.randomUUID()` → `SecureRandom`(32바이트)로 강화하고, Base64 URL-safe 인코딩 후 SHA-256 해시.

### 3. 응답 타입 검증 + 예외 분리

```kotlin
private fun extractIdToken(response: GetCredentialResponse): IdToken {
    val credential = response.credential
    check(
        credential is CustomCredential &&
            credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL,
    ) { \"Unexpected credential type: ${'$'}{credential::class.java.name}\" }
    return try {
        GoogleIdTokenCredential.createFrom(credential.data).idToken
    } catch (e: GoogleIdTokenParsingException) {
        throw IllegalStateException(\"Failed to parse Google ID token\", e)
    }
}
```

- 공식 가이드에 따라 `CustomCredential` + `TYPE_GOOGLE_ID_TOKEN_CREDENTIAL` 타입 검증 후 파싱.
- `GoogleIdTokenParsingException`을 별도 catch해서 \"파싱 실패\"임을 명확히 드러내는 메시지로 변환.

### 4. 의존성 stable 채널 전환

```toml
credentials = \"1.3.0\"   # was 1.3.0-alpha01
```

- `androidx.credentials` 1.3.0-alpha01 → **1.3.0 stable** (2024-10-02 출시).
- 더 최신(1.5.0/1.6.0)은 Kotlin 2.1 메타데이터로 컴파일되어 현 프로젝트 Kotlin 1.9.0과 비호환이므로 1.9 호환 마지막 stable인 1.3.0을 선택.
- `googleid`는 stable 채널의 `1.1.1` 유지 (1.2.0도 Kotlin 2.1 메타데이터).

## 공개 API 변경 없음

`requestSignInWithIdToken(): Result<IdToken>`, `requestSignOut(): Result<Unit>` 시그니처는 그대로라 호출부(`OnboardingViewModel`, `OnboardingScreen`)는 수정하지 않았습니다.

## KEY-POINT

- 처음 발견한 `[16] account reauth failed`는 Firebase Console에 디버그 키스토어 SHA-1/SHA-256이 등록되지 않아서 발생한 별개 이슈였고, 해당 등록은 이미 완료했습니다 (코드 변경 사항 아님).
- 추후 Kotlin/AGP 업그레이드 작업이 진행된다면 `androidx.credentials`도 1.5.x 이상으로 같이 올리는 것을 권장합니다.

## 테스트 — 종단간 검증 (Android 16 에뮬레이터)

| 단계 | 결과 |
|---|---|
| Credential Manager → Google ID 토큰 | ✅ 정상 발급 (`onUiEntrySelected` → `onFinalResponseReceived` → `GetCredentialResponse returned from framework`) |
| POST `/api/v1/auth/login-google` | ✅ 200 OK, `accessToken` + `alreadyExist` 정상 수신 |
| 후속 인증 API (`/api/v1/library`, `/api/v1/study/record/week`, `/api/v1/wise-saying`, `/api/v1/user/me`) | ✅ 200 OK |
| 홈 화면 진입 | ✅ `NavigateToHome` 사이드이펙트 발동 |

## CHECKLIST

- [x] 컴파일 통과 (`:core:auth:compileDebugKotlin`, `:app:assembleDebug`)
- [x] 종단간 로그인 동작 확인 (디버그 빌드 / 에뮬레이터)
- [ ] 신규 계정으로 로그인 (=2차 폴백 `GetSignInWithGoogleOption` 경로) 확인 — 리뷰어 추가 검증 부탁드립니다
- [ ] 릴리즈 빌드에서도 동일 동작 확인